### PR TITLE
TK-2514,TK-2515, TK-2519, TK-2520, TK-2537, TK-2521: preflight script and test suite bug fixes and improvements

### DIFF
--- a/hack/run-shell-lint.sh
+++ b/hack/run-shell-lint.sh
@@ -14,7 +14,7 @@ fi
 SRC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
 
 # run shell fmt
-shfmt_out="$(shfmt -l -i=2 "${SRC_ROOT}/hack" "${SRC_ROOT}/tools/preflight")"
+shfmt_out="$(shfmt -l -i=2 "${SRC_ROOT}/hack" "${SRC_ROOT}/tools/preflight" "${SRC_ROOT}/tests/preflight")"
 if [[ -n "${shfmt_out}" ]]; then
   echo >&2 "The following shell scripts need to be formatted, run: 'shfmt -w -i=2 ${SRC_ROOT}/hack ${SRC_ROOT}/tools/preflight'"
   echo >&2 "${shfmt_out}"

--- a/tests/preflight/preflight_test.sh
+++ b/tests/preflight/preflight_test.sh
@@ -13,7 +13,7 @@ take_input --storageclass csi-gce-pd --snapshotclass default-snapshot-class
 
 testKubectl() {
   check_kubectl
-    rc=$?
+  rc=$?
   # shellcheck disable=SC2181
   if [ $rc != "0" ]; then
     # shellcheck disable=SC2082
@@ -25,7 +25,7 @@ testKubectl() {
 testKubectlAccess() {
 
   check_kubectl_access
-    rc=$?
+  rc=$?
   # shellcheck disable=SC2181
   if [ $rc != "0" ]; then
     # shellcheck disable=SC2082
@@ -37,7 +37,7 @@ testKubectlAccess() {
 testHelmVersion() {
 
   check_helm_version
-    rc=$?
+  rc=$?
   # shellcheck disable=SC2181
   if [ $rc != "0" ]; then
     # shellcheck disable=SC2082
@@ -49,7 +49,7 @@ testHelmVersion() {
 testK8sVersion() {
 
   check_kubernetes_version
-    rc=$?
+  rc=$?
   # shellcheck disable=SC2181
   if [ $rc != "0" ]; then
     # shellcheck disable=SC2082
@@ -73,7 +73,7 @@ testK8sRBAC() {
 testStorageSnapshotClass() {
 
   check_storage_snapshot_class
-    rc=$?
+  rc=$?
   # shellcheck disable=SC2181
   if [ $rc != "0" ]; then
     # shellcheck disable=SC2082
@@ -85,7 +85,7 @@ testStorageSnapshotClass() {
 testCSI() {
 
   check_csi
-    rc=$?
+  rc=$?
   # shellcheck disable=SC2181
   if [ $rc != "0" ]; then
     # shellcheck disable=SC2082
@@ -97,7 +97,7 @@ testCSI() {
 testDNSResolution() {
 
   check_dns_resolution
-    rc=$?
+  rc=$?
   # shellcheck disable=SC2181
   if [ $rc != "0" ]; then
     # shellcheck disable=SC2082
@@ -109,7 +109,7 @@ testDNSResolution() {
 testVolumeSnapshot() {
 
   check_volume_snapshot
-    rc=$?
+  rc=$?
   # shellcheck disable=SC2181
   if [ $rc != "0" ]; then
     # shellcheck disable=SC2082

--- a/tests/preflight/preflight_test.sh
+++ b/tests/preflight/preflight_test.sh
@@ -7,7 +7,7 @@ set -eo pipefail
 source tools/preflight/preflight.sh --source-only
 
 catch() {
-   if [ "$1" != "0" ]; then
+  if [ "$1" != "0" ]; then
     echo "Error - return code $1 occurred on line no. $2"
   fi
   cleanup
@@ -19,8 +19,8 @@ take_input --storageclass csi-gce-pd --snapshotclass default-snapshot-class
 
 testKubectl() {
   check_kubectl
-   # shellcheck disable=SC2181
-   if [ "$?" != "0" ]; then
+  # shellcheck disable=SC2181
+  if [ "$?" != "0" ]; then
     # shellcheck disable=SC2082
     echo "Error - checking kubectl, Expected 0 got ${$?}"
   fi
@@ -29,18 +29,18 @@ testKubectl() {
 testKubectlAccess() {
 
   check_kubectl_access
-   # shellcheck disable=SC2181
-   if [ "$?" != "0" ]; then
+  # shellcheck disable=SC2181
+  if [ "$?" != "0" ]; then
     # shellcheck disable=SC2082
     echo "Error - checking kubectl access, Expected 0 got ${$?}"
   fi
 }
 
-testHelmTillerVersion() {
+testHelmVersion() {
 
-  check_helm_tiller_version
-   # shellcheck disable=SC2181
-   if [ "$?" != "0" ]; then
+  check_helm_version
+  # shellcheck disable=SC2181
+  if [ "$?" != "0" ]; then
     # shellcheck disable=SC2082
     echo "Error - checking helm tiller version, Expected 0 got ${$?}"
   fi
@@ -49,8 +49,8 @@ testHelmTillerVersion() {
 testK8sVersion() {
 
   check_kubernetes_version
-   # shellcheck disable=SC2181
-   if [ "$?" != "0" ]; then
+  # shellcheck disable=SC2181
+  if [ "$?" != "0" ]; then
     # shellcheck disable=SC2082
     echo "Error - checking kubernetes version, Expected 0 got ${$?}"
   fi
@@ -59,28 +59,18 @@ testK8sVersion() {
 testK8sRBAC() {
 
   check_kubernetes_rbac
-   # shellcheck disable=SC2181
-   if [ "$?" != "0" ]; then
+  # shellcheck disable=SC2181
+  if [ "$?" != "0" ]; then
     # shellcheck disable=SC2082
     echo "Error - checking kubernetes RBAC, Expected 0 got ${$?}"
-  fi
-}
-
-testFeatureGates() {
-
-  check_feature_gates
-   # shellcheck disable=SC2181
-   if [ "$?" != "0" ]; then
-    # shellcheck disable=SC2082
-    echo "Error - checking feature gates, Expected 0 got ${$?}"
   fi
 }
 
 testStorageSnapshotClass() {
 
   check_storage_snapshot_class
-   # shellcheck disable=SC2181
-   if [ "$?" != "0" ]; then
+  # shellcheck disable=SC2181
+  if [ "$?" != "0" ]; then
     # shellcheck disable=SC2082
     echo "Error - checking storage snapshot class, Expected 0 got ${$?}"
   fi
@@ -89,8 +79,8 @@ testStorageSnapshotClass() {
 testCSI() {
 
   check_csi
-   # shellcheck disable=SC2181
-   if [ "$?" != "0" ]; then
+  # shellcheck disable=SC2181
+  if [ "$?" != "0" ]; then
     # shellcheck disable=SC2082
     echo "Error - checking CSI Expected 0 got ${$?}"
   fi
@@ -99,8 +89,8 @@ testCSI() {
 testDNSResolution() {
 
   check_dns_resolution
-   # shellcheck disable=SC2181
-   if [ "$?" != "0" ]; then
+  # shellcheck disable=SC2181
+  if [ "$?" != "0" ]; then
     # shellcheck disable=SC2082
     echo "Error - checking DNS resolution, Expected 0 got ${$?}"
   fi
@@ -109,23 +99,19 @@ testDNSResolution() {
 testVolumeSnapshot() {
 
   check_volume_snapshot
-   # shellcheck disable=SC2181
-   if [ "$?" != "0" ]; then
+  # shellcheck disable=SC2181
+  if [ "$?" != "0" ]; then
     # shellcheck disable=SC2082
     echo "Error - checking volume snapshot, Expected 0 got ${$?}"
   fi
 }
 
-
 testKubectl
 testKubectlAccess
-testHelmTillerVersion
+testHelmVersion
 testK8sVersion
 testK8sRBAC
-testFeatureGates
 testStorageSnapshotClass
 testCSI
 testDNSResolution
 testVolumeSnapshot
-cleanup
-


### PR DESCRIPTION
Fixed issues -
-  script stuck forever if no value provided for flags
-  fixed minimum helm and k8s version
-  removed support for tiller check
- removed feature gate check as it's not needed for k8s v1.17+
- added common label on resources created by Preflight Check
- cleanup stuck forever while cleanup
- Preflight script exiting and starting cleaning if one of checks fails in the middle
- removed volumesnapshot v1alpha1 related part as min. supported k8s v1.17.0 
- --snapshotclass flag made optional