### PR TITLE
:sparkles: TK-3707 & 3706 Add flag to filter namespace and cluster sc…

### DIFF
--- a/cmd/target-browser/cmd/backup.go
+++ b/cmd/target-browser/cmd/backup.go
@@ -40,6 +40,12 @@ for specific backupPlan using available flags and options.`,
   # List of backups: filter by [backup-status]
   kubectl tvk-target-browser get backup --backup-plan-uid <uid> --backup-status Available --target-name <name> --target-namespace <namespace>
 
+  # List of backups in Single Namespace: filter by [operationScope]
+  kubectl tvk-target-browser get backup --operation-scope SingleNamespace --target-name <name> --target-namespace <namespace>
+
+  # List of backups in Multi Namespace/Cluster Scope: filter by [operationScope]
+  kubectl tvk-target-browser get backup --operation-scope MultiNamespace --target-name <name> --target-namespace <namespace>
+
   # List of backups: filter by [expiry-date] (NOT SUPPORTED)
   kubectl tvk-target-browser get backup --backup-plan-uid <uid> --expiry-date <date> --target-name <name> --target-namespace <namespace>
 

--- a/cmd/target-browser/cmd/backupPlan.go
+++ b/cmd/target-browser/cmd/backupPlan.go
@@ -36,6 +36,12 @@ using available flags and options.`,
   
   # List of backupPlans: filter by [tvkInstanceUID]
   kubectl tvk-target-browser get backupPlan --tvk-instance-uid <uid> --target-name <name> --target-namespace <namespace>
+  
+  # List of backupPlans in Single Namespace: filter by [operationScope]
+  kubectl tvk-target-browser get backupPlan --operation-scope SingleNamespace --target-name <name> --target-namespace <namespace>
+
+  # List of backupPlans in Multi Namespace/Cluster Scope: filter by [operationScope]
+  kubectl tvk-target-browser get backupPlan --operation-scope MultiNamespace --target-name <name> --target-namespace <namespace>
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return getBackupPlanList(args)

--- a/cmd/target-browser/cmd/constant.go
+++ b/cmd/target-browser/cmd/constant.go
@@ -76,7 +76,8 @@ const (
 	expiryDateUsage   = "Backup expiry date"
 
 	OperationScopeFlag  = "operation-scope"
-	operationScopeUsage = "Filter backup/backupPlan for [SingleNamespace, MultiNamespace]"
+	operationScopeUsage = "Filter backup/backupPlan for [SingleNamespace, MultiNamespace]. " +
+		"Supported values: SingleNamespace|MultiNamespace or singleNamespace|multiNamespace"
 )
 
 var (

--- a/cmd/target-browser/cmd/constant.go
+++ b/cmd/target-browser/cmd/constant.go
@@ -77,7 +77,7 @@ const (
 
 	OperationScopeFlag  = "operation-scope"
 	operationScopeUsage = "Filter backup/backupPlan for [SingleNamespace, MultiNamespace]. " +
-		"Supported values: SingleNamespace|MultiNamespace or singleNamespace|multiNamespace"
+		"Supported values can be in any case capital, small or mixed."
 )
 
 var (

--- a/cmd/target-browser/cmd/constant.go
+++ b/cmd/target-browser/cmd/constant.go
@@ -74,6 +74,9 @@ const (
 	expiryDateFlag    = "expiry-date"
 	expiryDateDefault = ""
 	expiryDateUsage   = "Backup expiry date"
+
+	OperationScopeFlag  = "operation-scope"
+	operationScopeUsage = "Filter backup/backupPlan for [SingleNamespace, MultiNamespace]"
 )
 
 var (
@@ -84,6 +87,7 @@ var (
 	creationDate    string
 	expiryDate      string
 	orderBy         string
+	operationScope  string
 	pages, pageSize int
 )
 

--- a/cmd/target-browser/cmd/get.go
+++ b/cmd/target-browser/cmd/get.go
@@ -86,11 +86,13 @@ func validateInput(cmd *cobra.Command) error {
 	}
 
 	if operationScope != "" {
-		val, isPresent := internal.ResourceScopeMap[strings.ToLower(operationScope)]
-		if !isPresent {
+		if strings.EqualFold(operationScope, internal.SingleNamespace) {
+			operationScope = internal.SingleNamespace
+		} else if strings.EqualFold(operationScope, internal.MultiNamespace) {
+			operationScope = internal.MultiNamespace
+		} else {
 			return fmt.Errorf("[%s] flag invalid value. Usage - %s", OperationScopeFlag, operationScopeUsage)
 		}
-		operationScope = val
 	}
 	return nil
 }

--- a/cmd/target-browser/cmd/get.go
+++ b/cmd/target-browser/cmd/get.go
@@ -47,10 +47,11 @@ which retrieves single object or list of objects of that resource.`,
 		}
 
 		commonOptions = targetbrowser.CommonListOptions{
-			Page:         pages,
-			PageSize:     pageSize,
-			OrderBy:      orderBy,
-			OutputFormat: outputFormat,
+			Page:           pages,
+			PageSize:       pageSize,
+			OrderBy:        orderBy,
+			OutputFormat:   outputFormat,
+			OperationScope: operationScope,
 		}
 
 		return nil
@@ -61,6 +62,7 @@ func init() {
 	getCmd.PersistentFlags().IntVar(&pages, pagesFlag, pagesDefault, pagesUsage)
 	getCmd.PersistentFlags().IntVar(&pageSize, PageSizeFlag, PageSizeDefault, pageSizeUsage)
 	getCmd.PersistentFlags().StringVar(&orderBy, OrderByFlag, orderByDefault, orderByUsage)
+	getCmd.PersistentFlags().StringVar(&operationScope, OperationScopeFlag, "", operationScopeUsage)
 	rootCmd.AddCommand(getCmd)
 }
 

--- a/cmd/target-browser/cmd/get.go
+++ b/cmd/target-browser/cmd/get.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -84,5 +85,12 @@ func validateInput(cmd *cobra.Command) error {
 		return fmt.Errorf("[%s] flag invalid value. Usage - %s", OutputFormatFlag, OutputFormatFlagUsage)
 	}
 
+	if operationScope != "" {
+		val, isPresent := internal.ResourceScopeMap[strings.ToLower(operationScope)]
+		if !isPresent {
+			return fmt.Errorf("[%s] flag invalid value. Usage - %s", OperationScopeFlag, operationScopeUsage)
+		}
+		operationScope = val
+	}
 	return nil
 }

--- a/docs/target-browser/README.md
+++ b/docs/target-browser/README.md
@@ -73,15 +73,24 @@ kubectl tvk-target-browser get metadata --help
   ```bash
   kubectl tvk-target-browser get backup --backup-plan-uid <uid> --target-name <name> --target-namespace <namespace>
   ```
+
  - Get list of backups for backupPlan:
 
   ```bash
   kubectl tvk-target-browser get backup --backup-plan-uid <uid> --target-name <name> --target-namespace <namespace>
   ```
-  
+
   - Get specific backup:
   ```bash
   kubectl tvk-target-browser get backup <backup-uid> --target-name <name> --target-namespace <namespace>
+  ```
+  - List of backups in Single Namespace:
+  ```bash
+  kubectl tvk-target-browser get backup --operation-scope SingleNamespace --target-name <name> --target-namespace <namespace>
+  ```
+  - List of backups in Multi Namespace/Cluster Scope:
+  ```bash
+   kubectl tvk-target-browser get backup --operation-scope MultiNamespace --target-name <name> --target-namespace <namespace>
   ```
 
   - Get list of backupPlans:
@@ -92,6 +101,14 @@ kubectl tvk-target-browser get metadata --help
   - Get specific backupPlan:
   ```bash
   kubectl tvk-target-browser get backupPlan <backup-plan-uid> --target-name <name> --target-namespace <namespace>
+  ```
+  - List of backupPlans in Single Namespace:
+  ```bash
+  kubectl tvk-target-browser get backupPlan --operation-scope SingleNamespace --target-name <name> --target-namespace <namespace>
+  ```
+  - List of backupPlans in Multi Namespace/Cluster Scope:
+  ```bash
+  kubectl tvk-target-browser get backupPlan --operation-scope MultiNamespace --target-name <name> --target-namespace <namespace>
   ```
 
   - Get metadata of specific backup:

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -25,8 +25,8 @@ const (
 	FormatYAML                = "yaml"
 	FormatJSON                = "json"
 	FormatWIDE                = "wide"
-	SingleNamespace           = "singlenamespace"
-	MultiNamespace            = "multinamespace"
+	SingleNamespace           = "SingleNamespace"
+	MultiNamespace            = "MultiNamespace"
 )
 
 var (

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -25,6 +25,8 @@ const (
 	FormatYAML                = "yaml"
 	FormatJSON                = "json"
 	FormatWIDE                = "wide"
+	SingleNamespace           = "singlenamespace"
+	MultiNamespace            = "multinamespace"
 )
 
 var (

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -4,5 +4,4 @@ import "k8s.io/apimachinery/pkg/util/sets"
 
 var (
 	AllowedOutputFormats = sets.NewString(FormatJSON, FormatYAML, FormatWIDE)
-	ResourceScopeMap     = map[string]string{SingleNamespace: "SingleNamespace", MultiNamespace: "MultiNamespace"}
 )

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -4,4 +4,5 @@ import "k8s.io/apimachinery/pkg/util/sets"
 
 var (
 	AllowedOutputFormats = sets.NewString(FormatJSON, FormatYAML, FormatWIDE)
+	ResourceScopeMap     = map[string]string{SingleNamespace: "SingleNamespace", MultiNamespace: "MultiNamespace"}
 )

--- a/tools/target-browser/commons.go
+++ b/tools/target-browser/commons.go
@@ -16,10 +16,11 @@ import (
 )
 
 type CommonListOptions struct {
-	Page         int    `url:"page"`
-	PageSize     int    `url:"pageSize"`
-	OrderBy      string `url:"ordering,omitempty"`
-	OutputFormat string
+	Page           int    `url:"page"`
+	PageSize       int    `url:"pageSize"`
+	OrderBy        string `url:"ordering,omitempty"`
+	OperationScope string `url:"operationScope,omitempty"`
+	OutputFormat   string
 }
 
 // ListMetadata for Pagination


### PR DESCRIPTION
Add filter in sub-command backup and backupPlan to get cluster scope and namespace resources

<!-- please add an icon to the title of this PR, and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
