### PR TITLE
✨ TK-4694: Added flags for dark site installation

### DIFF
--- a/docs/preflight/README.md
+++ b/docs/preflight/README.md
@@ -32,8 +32,8 @@ The following checks are included in preflight:
 - Ensures provided storageClass is present in cluster
   1. Provided storageClass's `provisioner` [JSON Path: `storageclass.provisioner`] should match with provided volumeSnapshotClass's `driver`[JSON Path: `volumesnapshotclass.driver`]
   2. If volumeSnapshotClass is not provided then, volumeSnapshotClass which satisfies condition `[i]` will be selected.
-  If there's are multiple volumeSnapshotClasses satisfying condition `[i]`, default volumeSnapshotClass[which has annotation `snapshot.storage.kubernetes.io/is-default-class: "true"` set]
-  will be used for further pre-flight checks.
+     If there's are multiple volumeSnapshotClasses satisfying condition `[i]`, default volumeSnapshotClass[which has annotation `snapshot.storage.kubernetes.io/is-default-class: "true"` set]
+     will be used for further pre-flight checks.
   3. Pre-flight check fails if no volumeSnapshotClass is found[after considering all above mentioned conditions].
 - Ensures at least one volumeSnapshotClass is marked as *default* in cluster if user has not provided volumeSnapshotClass as input.
 - Ensures all required features are present
@@ -49,7 +49,7 @@ The following checks are included in preflight:
   - Creates a Volume snapshot from a used PV (*snapshot-source-pvc-${RANDOM_STRING}*) from the *source-pvc-${RANDOM_STRING}*
   - Creates a volume snapshot from unused PV (delete the source pod before snapshoting)
   - Creates a restore Pod and PVC (*restored-pod-${RANDOM_STRING}* and *restored-pvc-${RANDOM_STRING}*)
-  - Creates a resotre Pod and PVC from unused pv snapshot
+  - Creates a restore Pod and PVC from unused pv snapshot
   - Ensure data in restored pod/pvc is correct
 - Cleanup of all the intermediate resources created during preflight checks' execution.
 
@@ -83,7 +83,7 @@ The following checks are included in preflight:
 ## Usage:
 
     kubectl tvk-preflight [flags]
-	
+
 - Flags:
 
 | Parameter                 | Default       | Description   |    
@@ -91,6 +91,10 @@ The following checks are included in preflight:
 | --storageclass          |             |Name of storage class being used in k8s cluster (Needed)
 | --snapshotclass          |            |Name of volume snapshot class being used in k8s cluster (Optional)
 | --kubeconfig            |   ~/.kube/config             |Kubeconfig path, if not given default is used by kubectl (Optional)
+| --local-registry        |             | Name of the local registry from where the images will be pulled (Optional)
+| --image-pull-secret     |             | Name of the secret for authentication while pulling the images from the local registry (Optional)
+| --service-account-name  |             | Name of the service account
+
 
 ## Examples
 

--- a/docs/preflight/README.md
+++ b/docs/preflight/README.md
@@ -114,7 +114,8 @@ NOT SUPPORTED
 
 **Note for Dark Site Installation**
 
-- For using the `local-registry` flag, it is mandatory to have `busybox` and `dnsutils:1.3` images to be there in the private registry.
+- For using the `local-registry` flag, it is mandatory to have `busybox:latest` and `dnsutils:1.3` images (with the same tags) to be there in the private registry. 
+
     > Steps for pushing images to local registry
     - Pull the images (dnsutils:1.3 & busybox) to local machine.
     - use the following command to push it to the local registry

--- a/docs/preflight/README.md
+++ b/docs/preflight/README.md
@@ -122,11 +122,11 @@ NOT SUPPORTED
 | Parameter                 | Default       | Description   |    
 | :------------------------ |:-------------:| :-------------|  
 | --storageclass          |             |Name of storage class being used in k8s cluster (Needed)
-| --snapshotclass          |            |Name of volume snapshot class being used in k8s cluster (Optional)
+| --snapshotclass         |             |Name of volume snapshot class being used in k8s cluster (Optional)
 | --kubeconfig            |   ~/.kube/config             |Kubeconfig path, if not given default is used by kubectl (Optional)
 | --local-registry        |             | Name of the local registry from where the images will be pulled (Optional)
 | --image-pull-secret     |             | Name of the secret for authentication while pulling the images from the local registry (Optional)
-| --service-account-name  |             | Name of the service account (Optional)
+| --service-account       |             | Name of the service account (Optional)
 
 
 ## Examples

--- a/docs/preflight/README.md
+++ b/docs/preflight/README.md
@@ -115,7 +115,11 @@ NOT SUPPORTED
 **Note for Dark Site Installation**
 
 - For using the `local-registry` flag, it is mandatory to have `busybox` and `dnsutils:1.3` images to be there in the private registry.
-
+    > Steps for pushing images to local registry
+    - Pull the images (dnsutils:1.3 & busybox) to local machine.
+    - use the following command to push it to the local registry
+    - `docker push <local registry/image>` 
+    - Example: `docker push localhost:5000/busybox`
 ## Usage:
 
     kubectl tvk-preflight [flags]
@@ -144,4 +148,16 @@ kubectl tvk-preflight --storageclass <storageclass name> --snapshotclass <volume
 
 ```shell script
 kubectl tvk-preflight --storageclass <storageclass name>
+```
+
+- With `--local-registry` | `--service-account`  :
+
+```shell script
+kubectl tvk-preflight --storageclass <storageclass name> --local-registry <local registry file path/name> --service-account <service account name>
+```
+
+- With `--image-pull-secret`  :
+
+```shell script
+kubectl tvk-preflight --storageclass <storageclass name> --local-registry <local registry file path/name> --image-pull-secret <image pull secret name>
 ```

--- a/docs/preflight/README.md
+++ b/docs/preflight/README.md
@@ -112,6 +112,9 @@ Verify installation with `kubectl tvk-preflight --help`
 ##### Windows
 NOT SUPPORTED
 
+**Note for Dark Site Installation**
+
+- For using the `local-registry` flag, it is mandatory to have `busybox` and `dnsutils:1.3` images to be there in the private registry.
 
 ## Usage:
 

--- a/tools/preflight/preflight.sh
+++ b/tools/preflight/preflight.sh
@@ -57,7 +57,7 @@ kubectl tvk-preflight --storageclass <storage_class_name> --snapshotclass <volum
 Params:
   --storageclass  name of storage class being used in k8s cluster
   --local-registry name of the local registry to get images from (OPTIONAL)
-  --service-account-name name of the service account (OPTIONAL)
+  --service-account name of the service account (OPTIONAL)
   --image-pull-secret name of the secret configured for authentication (OPTIONAL)
   --snapshotclass name of volume snapshot class being used in k8s cluster (OPTIONAL)
   --kubeconfig  path to kube config (OPTIONAL)
@@ -123,12 +123,12 @@ take_input() {
         exit 1
       fi
       ;;
-    --service-account-name)
+    --service-account)
       if [[ -n "$2" ]]; then
         SERVICE_ACCOUNT_NAME=$2
         shift 2
       else
-        echolog "Error: flag --service-account-name value may not be empty. Either set the value or skip this flag!"
+        echolog "Error: flag --service-account value may not be empty. Either set the value or skip this flag!"
         print_help
         exit 1
       fi
@@ -150,7 +150,7 @@ take_input() {
     exit 1
   fi
   if [[ -z "${LOCAL_REGISTRY}" && -n "${IMAGE_PULL_SECRET}" ]]; then
-    echo "Error Cannot Give Pull Secret if LOCAL_REGISTRY is not provided!"
+    echolog "Error: Cannot Give Pull Secret if local-registry is not provided!"
     exit 1
   fi
 }

--- a/tools/preflight/preflight.sh
+++ b/tools/preflight/preflight.sh
@@ -55,9 +55,12 @@ print_help() {
 Usage:
 kubectl tvk-preflight --storageclass <storage_class_name> --snapshotclass <volume_snapshot_class>
 Params:
-	--storageclass	name of storage class being used in k8s cluster
-	--snapshotclass name of volume snapshot class being used in k8s cluster (OPTIONAL)
-	--kubeconfig	path to kube config (OPTIONAL)
+  --storageclass  name of storage class being used in k8s cluster
+  --local-registry name of the local registry to get images from (OPTIONAL)
+  --service-account-name name of the service account (OPTIONAL)
+  --image-pull-secret name of the secret configured for authentication (OPTIONAL)
+  --snapshotclass name of volume snapshot class being used in k8s cluster (OPTIONAL)
+  --kubeconfig  path to kube config (OPTIONAL)
 --------------------------------------------------------------
 "
 }
@@ -100,6 +103,36 @@ take_input() {
         exit 1
       fi
       ;;
+    --local-registry)
+      if [[ -n "$2" ]]; then
+        LOCAL_REGISTRY=$2
+        shift 2
+      else
+        echolog "Error: flag --local-registry value may not be empty. Either set the value or skip this flag!"
+        print_help
+        exit 1
+      fi
+      ;;
+    --image-pull-secret)
+      if [[ -n "$2" ]]; then
+        IMAGE_PULL_SECRET=$2
+        shift 2
+      else
+        echolog "Error: flag --image-pull-secret value may not be empty. Either set the value or skip this flag!"
+        print_help
+        exit 1
+      fi
+      ;;
+    --service-account-name)
+      if [[ -n "$2" ]]; then
+        SERVICE_ACCOUNT_NAME=$2
+        shift 2
+      else
+        echolog "Error: flag --service-account-name value may not be empty. Either set the value or skip this flag!"
+        print_help
+        exit 1
+      fi
+      ;;
     -h | --help)
       print_help
       exit
@@ -114,6 +147,10 @@ take_input() {
   if [[ -z "${STORAGE_CLASS}" ]]; then
     echolog "Error: --storageclass flag needed to run pre flight checks!"
     print_help
+    exit 1
+  fi
+  if [[ -z "${LOCAL_REGISTRY}" && -n "${IMAGE_PULL_SECRET}" ]]; then
+    echo "Error Cannot Give Pull Secret if LOCAL_REGISTRY is not provided!"
     exit 1
   fi
 }
@@ -309,6 +346,11 @@ check_csi() {
 }
 
 check_dns_resolution() {
+  if [[ -n "${LOCAL_REGISTRY}" ]]; then
+    IMG_PATH=${LOCAL_REGISTRY}
+  else
+    IMG_PATH="gcr.io/kubernetes-e2e-test-images"
+  fi
   echolog "${LIGHT_BLUE}Checking if DNS resolution working in K8s cluster...${NC}\n"
   local exit_status=1
 
@@ -323,9 +365,12 @@ metadata:
     preflight-run: ${RANDOM_STRING}
     ${LABEL_K8S_PART_OF}: ${LABEL_K8S_PART_OF_VALUE}
 spec:
+  imagePullSecrets:
+    - name: ${IMAGE_PULL_SECRET}
+  serviceAccountName: ${SERVICE_ACCOUNT_NAME}
   containers:
   - name: dnsutils
-    image: gcr.io/kubernetes-e2e-test-images/dnsutils:1.3
+    image: ${IMG_PATH}/dnsutils:1.3
     command:
       - sleep
       - "3600"
@@ -371,6 +416,11 @@ EOF
 }
 
 check_volume_snapshot() {
+  if [[ -n "${LOCAL_REGISTRY}" ]]; then
+    IMG_PATH="${LOCAL_REGISTRY}/busybox"
+  else
+    IMG_PATH="busybox"
+  fi
   echolog "${LIGHT_BLUE}Checking if volume snapshot and restore enabled in K8s cluster...${NC}\n"
   local err_status=1
   local success_status=0
@@ -406,9 +456,12 @@ metadata:
     preflight-run: ${RANDOM_STRING}
     ${LABEL_K8S_PART_OF}: ${LABEL_K8S_PART_OF_VALUE}
 spec:
+  imagePullSecrets:
+  - name: ${IMAGE_PULL_SECRET}
+  serviceAccountName: ${SERVICE_ACCOUNT_NAME}
   containers:
   - name: busybox
-    image: busybox
+    image: ${IMG_PATH}
     command: ["/bin/sh", "-c"]
     args: ["touch /demo/data/sample-file.txt && sleep 3000"]
     resources:
@@ -524,9 +577,12 @@ metadata:
     preflight-run: ${RANDOM_STRING}
     ${LABEL_K8S_PART_OF}: ${LABEL_K8S_PART_OF_VALUE}
 spec:
+  imagePullSecrets:
+    - name: ${IMAGE_PULL_SECRET}
+  serviceAccountName: ${SERVICE_ACCOUNT_NAME}
   containers:
   - name: busybox
-    image: busybox
+    image: ${IMG_PATH}
     args:
     - sleep
     - "3600"
@@ -664,9 +720,12 @@ metadata:
     preflight-run: ${RANDOM_STRING}
     ${LABEL_K8S_PART_OF}: ${LABEL_K8S_PART_OF_VALUE}
 spec:
+  imagePullSecrets:
+    - name: ${IMAGE_PULL_SECRET}
+  serviceAccountName: ${SERVICE_ACCOUNT_NAME}
   containers:
   - name: busybox
-    image: busybox
+    image: ${IMG_PATH}
     args:
     - sleep
     - "3600"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR, and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
This PR contains the modifications to the preflight.sh, added the flag for `local-registry`, `service-account` and `image-pull-secret` so that dark site installation picks up images from (with or without authentication) local registry.