### PR TITLE
:seedling: TK-4853 Add support for providing preflight inputs through a yaml file

### DIFF
--- a/cmd/preflight/cmd/cleanup.go
+++ b/cmd/preflight/cmd/cleanup.go
@@ -18,16 +18,16 @@ var cleanupCmd = &cobra.Command{
 	Long: `Cleans-up the resources that were created during preflight checks.
 If uid flag is not specified then all preflight resources created till date are deleted.`,
 	Example: ` # clean preflight resources with a particular uid
-  kubectl tvk-preflight cleanup --uid <preflight Run uid> --namespace <namespace>
+  kubectl tvk-preflight cleanup --uid <preflight run uid> --namespace <namespace>
 
   # clean all preflight resources created till date
   kubectl tvk-preflight cleanup --namespace <namespace>
 
   # clean preflight resource with a specified logging level
-  kubectl tvk-preflight cleanup --uid <preflight Run uid> --log-level <log-level>
+  kubectl tvk-preflight cleanup --uid <preflight run uid> --log-level <log-level>
 
   # Cleanup preflight resources with a particular kubeconfig file
-  kubectl tvk-preflight cleanup --uid <preflight Run uid> --namespace <namespace> --kubeconfig <kubeconfig-file-path>
+  kubectl tvk-preflight cleanup --uid <preflight run uid> --namespace <namespace> --kubeconfig <kubeconfig-file-path>
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error

--- a/cmd/preflight/cmd/cleanup.go
+++ b/cmd/preflight/cmd/cleanup.go
@@ -11,23 +11,23 @@ import (
 	"github.com/trilioData/tvk-plugins/tools/preflight"
 )
 
-// cleanupCmd represents the cleanup command
+// cleanupCmd represents the Cleanup command
 var cleanupCmd = &cobra.Command{
 	Use:   cleanupCmdName,
 	Short: "Cleans-up the preflight resources created during preflight checks.",
 	Long: `Cleans-up the resources that were created during preflight checks.
 If uid flag is not specified then all preflight resources created till date are deleted.`,
 	Example: ` # clean preflight resources with a particular uid
-  kubectl tvk-preflight cleanup --uid <preflight run uid> --namespace <namespace>
+  kubectl tvk-preflight cleanup --uid <preflight Run uid> --namespace <namespace>
 
   # clean all preflight resources created till date
   kubectl tvk-preflight cleanup --namespace <namespace>
 
   # clean preflight resource with a specified logging level
-  kubectl tvk-preflight cleanup --uid <preflight run uid> --log-level <log-level>
+  kubectl tvk-preflight cleanup --uid <preflight Run uid> --log-level <log-level>
 
-  # cleanup preflight resources with a particular kubeconfig file
-  kubectl tvk-preflight cleanup --uid <preflight run uid> --namespace <namespace> --kubeconfig <kubeconfig-file-path>
+  # Cleanup preflight resources with a particular kubeconfig file
+  kubectl tvk-preflight cleanup --uid <preflight Run uid> --namespace <namespace> --kubeconfig <kubeconfig-file-path>
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
@@ -35,11 +35,11 @@ If uid flag is not specified then all preflight resources created till date are 
 		if err != nil {
 			return err
 		}
-		err = setupLogger(cleanupLogFilePrefix, cmdOps.CleanupOps.LogLevel)
+		err = setupLogger(cleanupLogFilePrefix, cmdOps.Cleanup.LogLevel)
 		if err != nil {
 			return err
 		}
-		err = preflight.InitKubeEnv(cmdOps.CleanupOps.Kubeconfig)
+		err = preflight.InitKubeEnv(cmdOps.Cleanup.Kubeconfig)
 		if err != nil {
 			return err
 		}
@@ -51,15 +51,14 @@ If uid flag is not specified then all preflight resources created till date are 
 		defer logFile.Close()
 		logger.SetOutput(io.MultiWriter(colorable.NewColorableStdout(), logFile))
 
-		cmdOps.CleanupOps.Logger = logger
-		logRootCmdFlagsInfo(cmdOps.CleanupOps.Namespace, cmdOps.CleanupOps.Kubeconfig)
+		cmdOps.Cleanup.Logger = logger
 
 		err = validateCleanupFields()
 		if err != nil {
 			return err
 		}
 
-		err = cmdOps.CleanupOps.CleanupPreflightResources(context.Background(), cleanupUID)
+		err = cmdOps.Cleanup.CleanupPreflightResources(context.Background())
 
 		return err
 	},
@@ -69,5 +68,4 @@ func init() {
 	rootCmd.AddCommand(cleanupCmd)
 
 	cleanupCmd.Flags().StringVar(&cleanupUID, uidFlag, "", uidUsage)
-	cleanupCmd.Flags().StringVar(&cleanupMode, cleanupModeFlag, defaultCleanupMode, cleanupModeUsage)
 }

--- a/cmd/preflight/cmd/constants.go
+++ b/cmd/preflight/cmd/constants.go
@@ -5,56 +5,53 @@ const (
 	preflightRunCmdName = "run"
 	cleanupCmdName      = "cleanup"
 
-	namespaceFlag          = "namespace"
+	NamespaceFlag          = "namespace"
 	namespaceFlagShorthand = "n"
 	namespaceUsage         = "Namespace of the cluster in which the preflight checks will be performed"
 
-	storageClassFlag  = "storage-class"
+	StorageClassFlag  = "storage-class"
 	storageClassUsage = "Name of storage class to use for preflight checks"
 
-	snapshotClassFlag  = "volume-snapshot-class"
+	SnapshotClassFlag  = "volume-snapshot-class"
 	snapshotClassUsage = "Name of volume snapshot class to use for preflight checks"
 
-	localRegistryFlag  = "local-registry"
+	LocalRegistryFlag  = "local-registry"
 	localRegistryUsage = "Name of the local registry from where the images will be pulled"
 
 	imagePullSecFlag  = "image-pull-secret"
 	imagePullSecUsage = "Name of the secret for authentication while pulling the images from the local registry"
 
-	serviceAccountFlag  = "service-account"
+	ServiceAccountFlag  = "service-account"
 	serviceAccountUsage = "Name of the service account to use for preflight checks and creating preflight resources"
 
-	cleanupOnFailureFlag  = "cleanup-on-failure"
+	CleanupOnFailureFlag  = "cleanup-on-failure"
 	cleanupOnFailureUsage = "Cleanup the resources on cluster if preflight checks fail. By-default it is false"
 
-	configFileFlag      = "config-file"
+	ConfigFileFlag      = "config-file"
 	configFileUsage     = "Specify the name of the yaml file for inputs to the preflight Run and Cleanup commands"
 	configFlagShorthand = "f"
 
-	podLimitFlag  = "limits"
-	podLimitUsage = "Pod memory and cpu resource limits for volume snapshot preflight check"
+	PodLimitFlag  = "limits"
+	podLimitUsage = "Pod memory and cpu resource limits for DNS and volume snapshot preflight check"
 
-	podRequestFlag  = "requests"
-	podRequestUsage = "Pod memory and cpu resource requests for volume snapshot preflight check"
+	PodRequestFlag  = "requests"
+	podRequestUsage = "Pod memory and cpu resource requests for DNS and volume snapshot preflight check"
 
-	pvcStorageRequestFlag  = "pvc-storage-request"
+	PVCStorageRequestFlag  = "pvc-storage-request"
 	pvcStorageRequestUsage = "PVC storage request for volume snapshot preflight check"
 
 	uidFlag  = "uid"
 	uidUsage = "UID of the preflight check whose resources must be cleaned"
 
-	defaultCleanupMode = "all"
-	uidCleanupMode     = "uid"
-
 	preflightLogFilePrefix = "preflight"
 	cleanupLogFilePrefix   = "preflight_cleanup"
 	preflightUIDLength     = 6
 
-	defaultPodRequestCPU    = "250m"
-	defaultPodRequestMemory = "64Mi"
-	defaultPodLimitCPU      = "500m"
-	defaultPodLimitMemory   = "128Mi"
-	defaultPVCStorage       = "1Gi"
+	DefaultPodRequestCPU    = "250m"
+	DefaultPodRequestMemory = "64Mi"
+	DefaultPodLimitCPU      = "500m"
+	DefaultPodLimitMemory   = "128Mi"
+	DefaultPVCStorage       = "1Gi"
 
 	filePermission = 0644
 )

--- a/cmd/preflight/cmd/constants.go
+++ b/cmd/preflight/cmd/constants.go
@@ -27,11 +27,35 @@ const (
 	cleanupOnFailureFlag  = "cleanup-on-failure"
 	cleanupOnFailureUsage = "Cleanup the resources on cluster if preflight checks fail. By-default it is false"
 
+	inputFileFlag      = "input-file"
+	inputFileUsage     = "Specify the name of the yaml file for inputs to the preflight run and cleanup commands"
+	inputFlagShorthand = "f"
+
+	requestMemoryFlag  = "req-memory"
+	requestMemoryUsage = "Memory request requirement of all pods for volume snapshot preflight check"
+
+	limitMemoryFlag  = "lim-memory"
+	limitMemoryUsage = "Memory limit requirement of all pods for volume snapshot preflight check"
+
+	requestCPUFlag  = "req-cpu"
+	requestCPUUsage = "CPU request requirement of all pods for volume snapshot preflight check"
+
+	limitCPUFlag  = "lim-cpu"
+	limitCPUUsage = "CPU limit requirement of all pods for volume snapshot preflight check"
+
 	uidFlag  = "uid"
 	uidUsage = "UID of the preflight check whose resources must be cleaned"
 
+	cleanupModeFlag  = "cleanup-mode"
+	cleanupModeUsage = "Specifies the mode of cleanup; " +
+		"'all' to clean all generated preflight resources till date in the give namespace" +
+		"'uid' to clean preflight resources of particular run in the given namespace"
+	defaultCleanupMode = "all"
+	uidCleanupMode     = "uid"
+
 	preflightLogFilePrefix = "preflight"
 	cleanupLogFilePrefix   = "preflight_cleanup"
+	preflightUIDLength     = 6
 
 	filePermission = 0644
 )
@@ -46,6 +70,12 @@ var (
 	imagePullSecret  string
 	serviceAccount   string
 	cleanupOnFailure bool
+	inputFileName    string
+	requestMemory    string
+	limitMemory      string
+	requestCPU       string
+	limitCPU         string
 
-	cleanupUID string
+	cleanupUID  string
+	cleanupMode string
 )

--- a/cmd/preflight/cmd/constants.go
+++ b/cmd/preflight/cmd/constants.go
@@ -27,29 +27,22 @@ const (
 	cleanupOnFailureFlag  = "cleanup-on-failure"
 	cleanupOnFailureUsage = "Cleanup the resources on cluster if preflight checks fail. By-default it is false"
 
-	inputFileFlag      = "input-file"
-	inputFileUsage     = "Specify the name of the yaml file for inputs to the preflight run and cleanup commands"
-	inputFlagShorthand = "f"
+	configFileFlag      = "config-file"
+	configFileUsage     = "Specify the name of the yaml file for inputs to the preflight Run and Cleanup commands"
+	configFlagShorthand = "f"
 
-	requestMemoryFlag  = "req-memory"
-	requestMemoryUsage = "Memory request requirement of all pods for volume snapshot preflight check"
+	podLimitFlag  = "limits"
+	podLimitUsage = "Pod memory and cpu resource limits for volume snapshot preflight check"
 
-	limitMemoryFlag  = "lim-memory"
-	limitMemoryUsage = "Memory limit requirement of all pods for volume snapshot preflight check"
+	podRequestFlag  = "requests"
+	podRequestUsage = "Pod memory and cpu resource requests for volume snapshot preflight check"
 
-	requestCPUFlag  = "req-cpu"
-	requestCPUUsage = "CPU request requirement of all pods for volume snapshot preflight check"
-
-	limitCPUFlag  = "lim-cpu"
-	limitCPUUsage = "CPU limit requirement of all pods for volume snapshot preflight check"
+	pvcStorageRequestFlag  = "pvc-storage-request"
+	pvcStorageRequestUsage = "PVC storage request for volume snapshot preflight check"
 
 	uidFlag  = "uid"
 	uidUsage = "UID of the preflight check whose resources must be cleaned"
 
-	cleanupModeFlag  = "cleanup-mode"
-	cleanupModeUsage = "Specifies the mode of cleanup; " +
-		"'all' to clean all generated preflight resources till date in the give namespace" +
-		"'uid' to clean preflight resources of particular run in the given namespace"
 	defaultCleanupMode = "all"
 	uidCleanupMode     = "uid"
 
@@ -57,25 +50,28 @@ const (
 	cleanupLogFilePrefix   = "preflight_cleanup"
 	preflightUIDLength     = 6
 
+	defaultPodRequestCPU    = "250m"
+	defaultPodRequestMemory = "64Mi"
+	defaultPodLimitCPU      = "500m"
+	defaultPodLimitMemory   = "128Mi"
+	defaultPVCStorage       = "1Gi"
+
 	filePermission = 0644
 )
 
 var (
-	kubeconfig       string
-	namespace        string
-	logLevel         string
-	storageClass     string
-	snapshotClass    string
-	localRegistry    string
-	imagePullSecret  string
-	serviceAccount   string
-	cleanupOnFailure bool
-	inputFileName    string
-	requestMemory    string
-	limitMemory      string
-	requestCPU       string
-	limitCPU         string
-
-	cleanupUID  string
-	cleanupMode string
+	kubeconfig        string
+	namespace         string
+	logLevel          string
+	storageClass      string
+	snapshotClass     string
+	localRegistry     string
+	imagePullSecret   string
+	serviceAccount    string
+	cleanupOnFailure  bool
+	inputFileName     string
+	podLimits         string
+	podRequests       string
+	pvcStorageRequest string
+	cleanupUID        string
 )

--- a/cmd/preflight/cmd/helper.go
+++ b/cmd/preflight/cmd/helper.go
@@ -88,35 +88,35 @@ func managePreflightInputs(cmd *cobra.Command) (err error) {
 func overridePreflightFileInputsFromCLI(cmd *cobra.Command) error {
 	updateCommonInputsFromCLI(cmd, &cmdOps.Run.CommonOptions)
 
-	if cmd.Flags().Changed(storageClassFlag) {
+	if cmd.Flags().Changed(StorageClassFlag) {
 		cmdOps.Run.StorageClass = storageClass
 	}
-	if cmd.Flags().Changed(snapshotClassFlag) {
+	if cmd.Flags().Changed(SnapshotClassFlag) {
 		cmdOps.Run.SnapshotClass = snapshotClass
 	}
-	if cmd.Flags().Changed(localRegistryFlag) {
+	if cmd.Flags().Changed(LocalRegistryFlag) {
 		cmdOps.Run.LocalRegistry = localRegistry
 	}
 	if cmd.Flags().Changed(imagePullSecFlag) {
 		cmdOps.Run.ImagePullSecret = imagePullSecret
 	}
-	if cmd.Flags().Changed(serviceAccountFlag) {
+	if cmd.Flags().Changed(ServiceAccountFlag) {
 		cmdOps.Run.ServiceAccountName = serviceAccount
 	}
-	if cmd.Flags().Changed(cleanupOnFailureFlag) {
+	if cmd.Flags().Changed(CleanupOnFailureFlag) {
 		cmdOps.Run.PerformCleanupOnFail = cleanupOnFailure
 	}
-	if cmd.Flags().Changed(pvcStorageRequestFlag) {
+	if cmd.Flags().Changed(PVCStorageRequestFlag) {
 		cmdOps.Run.PVCStorageRequest = resource.MustParse(pvcStorageRequest)
 	} else if cmdOps.Run.PVCStorageRequest.Value() == 0 {
-		cmdOps.Run.PVCStorageRequest = resource.MustParse(defaultPVCStorage)
+		cmdOps.Run.PVCStorageRequest = resource.MustParse(DefaultPVCStorage)
 	}
 
 	return updateResReqFromCLI()
 }
 
 func updateCommonInputsFromCLI(cmd *cobra.Command, comnOps *preflight.CommonOptions) {
-	if cmd.Flags().Changed(namespaceFlag) || comnOps.Namespace == "" {
+	if cmd.Flags().Changed(NamespaceFlag) || comnOps.Namespace == "" {
 		comnOps.Namespace = namespace
 	}
 	if cmd.Flags().Changed(internal.KubeconfigFlag) || comnOps.Kubeconfig == "" {
@@ -142,10 +142,10 @@ func updateResReqFromCLI() error {
 		}
 
 		if requests.Cpu().Value() != 0 {
-			cmdOps.Run.Requests["cpu"] = requests["cpu"]
+			cmdOps.Run.Requests[corev1.ResourceCPU] = requests[corev1.ResourceCPU]
 		}
 		if requests.Memory().Value() != 0 {
-			cmdOps.Run.Requests["memory"] = requests["memory"]
+			cmdOps.Run.Requests[corev1.ResourceMemory] = requests[corev1.ResourceMemory]
 		}
 	}
 
@@ -156,10 +156,10 @@ func updateResReqFromCLI() error {
 		}
 
 		if limits.Cpu().Value() != 0 {
-			cmdOps.Run.Limits["cpu"] = limits["cpu"]
+			cmdOps.Run.Limits[corev1.ResourceCPU] = limits[corev1.ResourceCPU]
 		}
 		if limits.Memory().Value() != 0 {
-			cmdOps.Run.Limits["memory"] = limits["memory"]
+			cmdOps.Run.Limits[corev1.ResourceMemory] = limits[corev1.ResourceMemory]
 		}
 	}
 
@@ -226,8 +226,8 @@ func validateRunOptions() error {
 }
 
 func validateCleanupFields() error {
-	if cmdOps.Cleanup.CleanupMode == uidCleanupMode && len(cmdOps.Cleanup.UID) != preflightUIDLength {
-		return fmt.Errorf("valid 6-length preflight UID must be specified when Cleanup mode is %s", uidCleanupMode)
+	if cmdOps.Cleanup.UID != "" && len(cmdOps.Cleanup.UID) != preflightUIDLength {
+		return fmt.Errorf("valid 6-length preflight UID must be specified")
 	}
 
 	return nil
@@ -237,22 +237,18 @@ func overrideCleanupFileInputsFromCLI(cmd *cobra.Command) {
 	updateCommonInputsFromCLI(cmd, &cmdOps.Cleanup.CommonOptions)
 
 	if cmd.Flags().Changed(uidFlag) {
-		cmdOps.Cleanup.CleanupMode = uidCleanupMode
 		cmdOps.Cleanup.UID = cleanupUID
-	}
-	if cmdOps.Cleanup.CleanupMode == "" {
-		cmdOps.Cleanup.CleanupMode = defaultCleanupMode
 	}
 }
 
 func setResReqDefaultValues() {
 	cmdOps.Run.ResourceRequirements = corev1.ResourceRequirements{}
 	cmdOps.Run.Requests = map[corev1.ResourceName]resource.Quantity{
-		"cpu":    resource.MustParse(defaultPodRequestCPU),
-		"memory": resource.MustParse(defaultPodRequestMemory),
+		corev1.ResourceCPU:    resource.MustParse(DefaultPodRequestCPU),
+		corev1.ResourceMemory: resource.MustParse(DefaultPodRequestMemory),
 	}
 	cmdOps.Run.Limits = map[corev1.ResourceName]resource.Quantity{
-		"cpu":    resource.MustParse(defaultPodLimitCPU),
-		"memory": resource.MustParse(defaultPodLimitMemory),
+		corev1.ResourceCPU:    resource.MustParse(DefaultPodLimitCPU),
+		corev1.ResourceMemory: resource.MustParse(DefaultPodLimitMemory),
 	}
 }

--- a/cmd/preflight/cmd/helper.go
+++ b/cmd/preflight/cmd/helper.go
@@ -1,17 +1,32 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"github.com/trilioData/tvk-plugins/internal"
+	"github.com/trilioData/tvk-plugins/tools/preflight"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"sigs.k8s.io/yaml"
 )
 
-func setupLogger(logFilePrefix string) error {
+type preflightCmdOps struct {
+	PreflightOps preflight.Options        `json:"preflightOptions"`
+	CleanupOps   preflight.CleanupOptions `json:"cleanupOptions"`
+}
+
+func setupLogger(logFilePrefix, logLvl string) error {
 	var err error
 	preflightLogFilename = generateLogFileName(logFilePrefix)
 	logFile, err = os.OpenFile(preflightLogFilename, os.O_CREATE|os.O_WRONLY, filePermission)
@@ -22,13 +37,13 @@ func setupLogger(logFilePrefix string) error {
 	defer logFile.Close()
 	logger.SetOutput(io.MultiWriter(colorable.NewColorableStdout(), logFile))
 	logger.Infof("Created log file with name - %s", logFile.Name())
-	lvl, err := log.ParseLevel(logLevel)
+	lvl, err := log.ParseLevel(logLvl)
 	if err != nil {
 		logger.SetLevel(log.InfoLevel)
 		logger.Errorf("Failed to parse log-level flag. Setting log level as %s\n", internal.DefaultLogLevel)
 		return nil
 	}
-	logger.Infof("Setting log level as %s\n", logLevel)
+	logger.Infof("Setting log level as %s\n", strings.ToLower(logLvl))
 	logger.SetLevel(lvl)
 
 	return nil
@@ -43,7 +58,177 @@ func generateLogFileName(logFilePrefix string) string {
 	return logFilePrefix + "-" + ts + ".log"
 }
 
-func logRootCmdFlagsInfo() {
-	logger.Infof("Using '%s' namespace of the cluster", namespace)
-	logger.Infof("Using kubeconfig file path - %s", kubeconfig)
+func logRootCmdFlagsInfo(nspace, kubeConf string) {
+	logger.Infof(fmt.Sprintf("Using '%s' namespace of the cluster", nspace))
+	logger.Infof(fmt.Sprintf("Using kubeconfig file path - %s", kubeConf))
+}
+
+// reads preflight and cleanup inputs from file
+// override the flag inputs of file if given through CLI
+func readFileInputOptions(filename string) error {
+	var data []byte
+	data, err = ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	err = yaml.UnmarshalStrict(data, &cmdOps)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func managePreflightInputs(cmd *cobra.Command) (err error) {
+	if inputFileName != "" {
+		err = readFileInputOptions(inputFileName)
+		if err != nil {
+			return fmt.Errorf("failed to read preflight input from file :: %s", err.Error())
+		}
+		overridePreflightFileInputsFromCLI(cmd)
+	} else {
+		cmdOps.PreflightOps = preflight.Options{
+			CommonOptions: preflight.CommonOptions{
+				Kubeconfig: kubeconfig,
+				Namespace:  namespace,
+				LogLevel:   logLevel,
+			},
+			StorageClass:         storageClass,
+			SnapshotClass:        snapshotClass,
+			LocalRegistry:        localRegistry,
+			ImagePullSecret:      imagePullSecret,
+			ServiceAccountName:   serviceAccount,
+			PerformCleanupOnFail: cleanupOnFailure,
+		}
+		updateResReqFromCLI(cmd)
+	}
+
+	return nil
+}
+
+func overridePreflightFileInputsFromCLI(cmd *cobra.Command) {
+	updateCommonInputsFromCLI(cmd, &cmdOps.PreflightOps.CommonOptions)
+
+	if cmd.Flags().Changed(storageClassFlag) {
+		cmdOps.PreflightOps.StorageClass = storageClass
+	}
+	if cmd.Flags().Changed(snapshotClassFlag) {
+		cmdOps.PreflightOps.SnapshotClass = snapshotClass
+	}
+	if cmd.Flags().Changed(localRegistryFlag) {
+		cmdOps.PreflightOps.LocalRegistry = localRegistry
+	}
+	if cmd.Flags().Changed(imagePullSecFlag) {
+		cmdOps.PreflightOps.ImagePullSecret = imagePullSecret
+	}
+	if cmd.Flags().Changed(serviceAccountFlag) {
+		cmdOps.PreflightOps.ServiceAccountName = serviceAccount
+	}
+	if cmd.Flags().Changed(cleanupOnFailureFlag) {
+		cmdOps.PreflightOps.PerformCleanupOnFail = cleanupOnFailure
+	}
+
+	updateResReqFromCLI(cmd)
+}
+
+func updateCommonInputsFromCLI(cmd *cobra.Command, comnOps *preflight.CommonOptions) {
+	if cmd.Flags().Changed(namespaceFlag) || comnOps.Namespace == "" {
+		comnOps.Namespace = namespace
+	}
+	if cmd.Flags().Changed(internal.KubeconfigFlag) || comnOps.Kubeconfig == "" {
+		comnOps.Kubeconfig = kubeconfig
+	}
+	if cmd.Flags().Changed(internal.LogLevelFlag) || comnOps.LogLevel == "" {
+		comnOps.LogLevel = logLevel
+	}
+}
+
+func updateResReqFromCLI(cmd *cobra.Command) {
+	if cmd.Flags().Changed(requestMemoryFlag) {
+		if cmdOps.PreflightOps.PodResourceRequirements.Requests == nil {
+			cmdOps.PreflightOps.PodResourceRequirements.Requests = corev1.ResourceList{}
+		}
+		cmdOps.PreflightOps.PodResourceRequirements.Requests["memory"] = resource.MustParse(requestMemory)
+	}
+	if cmd.Flags().Changed(limitMemoryFlag) {
+		if cmdOps.PreflightOps.PodResourceRequirements.Limits == nil {
+			cmdOps.PreflightOps.PodResourceRequirements.Limits = corev1.ResourceList{}
+		}
+		cmdOps.PreflightOps.PodResourceRequirements.Limits["memory"] = resource.MustParse(limitMemory)
+	}
+	if cmd.Flags().Changed(requestCPUFlag) {
+		if cmdOps.PreflightOps.PodResourceRequirements.Requests == nil {
+			cmdOps.PreflightOps.PodResourceRequirements.Requests = corev1.ResourceList{}
+		}
+		cmdOps.PreflightOps.PodResourceRequirements.Requests["cpu"] = resource.MustParse(requestCPU)
+	}
+	if cmd.Flags().Changed(limitCPUFlag) {
+		if cmdOps.PreflightOps.PodResourceRequirements.Limits == nil {
+			cmdOps.PreflightOps.PodResourceRequirements.Limits = corev1.ResourceList{}
+		}
+		cmdOps.PreflightOps.PodResourceRequirements.Limits["cpu"] = resource.MustParse(limitCPU)
+	}
+}
+
+func manageCleanupInputs(cmd *cobra.Command) (err error) {
+	if inputFileName != "" {
+		err = readFileInputOptions(inputFileName)
+		if err != nil {
+			return err
+		}
+		overrideCleanupFileInputsFromCLI(cmd)
+	} else {
+		cmdOps.CleanupOps = preflight.CleanupOptions{
+			CommonOptions: preflight.CommonOptions{
+				Kubeconfig: kubeconfig,
+				Namespace:  namespace,
+				LogLevel:   logLevel,
+			},
+		}
+	}
+
+	return nil
+}
+
+func validateResourceRequirementsField() error {
+	reqMem := cmdOps.PreflightOps.PodResourceRequirements.Requests.Memory()
+	limitMem := cmdOps.PreflightOps.PodResourceRequirements.Limits.Memory()
+	if (reqMem.Value() == 0 && limitMem.Value() != 0) || (reqMem.Value() != 0 && limitMem.Value() == 0) {
+		return fmt.Errorf("non-zero memory requirement must be specified or skipped for both requests and limits. " +
+			"Memory requirement for only request or limit should not be specified")
+	}
+	if (reqMem != nil && limitMem != nil) && (reqMem.Value() > limitMem.Value()) {
+		return fmt.Errorf("request memory cannot be greater than limit memory")
+	}
+
+	reqCPU := cmdOps.PreflightOps.PodResourceRequirements.Requests.Cpu()
+	limitCPU := cmdOps.PreflightOps.PodResourceRequirements.Limits.Cpu()
+	if (reqCPU.Value() == 0 && limitCPU.Value() != 0) || (reqCPU.Value() != 0 && limitCPU.Value() == 0) {
+		return fmt.Errorf("non-zero CPU requirement must be specified or skipped for both requests and limits. " +
+			"CPU requirement for only request or limit should not be specified")
+	}
+	if (reqCPU != nil && limitCPU != nil) && (reqCPU.AsApproximateFloat64() > limitCPU.AsApproximateFloat64()) {
+		return fmt.Errorf("request CPU cannot be greater than limit CPU")
+	}
+
+	return nil
+}
+
+func validateCleanupFields() error {
+	if cmdOps.CleanupOps.CleanupMode == uidCleanupMode && len(cmdOps.CleanupOps.UID) != preflightUIDLength {
+		return fmt.Errorf("valid 6-length preflight UID must be specified when cleanup mode is %s", uidCleanupMode)
+	}
+
+	return nil
+}
+
+func overrideCleanupFileInputsFromCLI(cmd *cobra.Command) {
+	updateCommonInputsFromCLI(cmd, &cmdOps.CleanupOps.CommonOptions)
+
+	if cmd.Flags().Changed(cleanupModeFlag) || cmdOps.CleanupOps.CleanupMode == "" {
+		cmdOps.CleanupOps.CleanupMode = defaultCleanupMode
+	}
+	if cmdOps.CleanupOps.CleanupMode == uidCleanupMode && cmd.Flags().Changed(uidFlag) {
+		cmdOps.CleanupOps.UID = cleanupUID
+	}
 }

--- a/cmd/preflight/cmd/root.go
+++ b/cmd/preflight/cmd/root.go
@@ -38,10 +38,10 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&kubeconfig, internal.KubeconfigFlag,
 		internal.KubeconfigShorthandFlag, internal.KubeConfigDefault, internal.KubeconfigUsage)
-	rootCmd.PersistentFlags().StringVarP(&namespace, namespaceFlag, namespaceFlagShorthand, internal.DefaultNs, namespaceUsage)
+	rootCmd.PersistentFlags().StringVarP(&namespace, NamespaceFlag, namespaceFlagShorthand, internal.DefaultNs, namespaceUsage)
 	rootCmd.PersistentFlags().StringVarP(&logLevel, internal.LogLevelFlag,
 		internal.LogLevelFlagShorthand, internal.DefaultLogLevel, internal.LogLevelUsage)
-	rootCmd.PersistentFlags().StringVarP(&inputFileName, configFileFlag, configFlagShorthand, "", configFileUsage)
+	rootCmd.PersistentFlags().StringVarP(&inputFileName, ConfigFileFlag, configFlagShorthand, "", configFileUsage)
 
 	logger = logrus.New()
 	logger.SetFormatter(&logrus.TextFormatter{ForceColors: true})

--- a/cmd/preflight/cmd/root.go
+++ b/cmd/preflight/cmd/root.go
@@ -13,6 +13,8 @@ var (
 	logger               *logrus.Logger
 	logFile              *os.File
 	preflightLogFilename string
+	cmdOps               preflightCmdOps
+	err                  error
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -39,6 +41,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&namespace, namespaceFlag, namespaceFlagShorthand, internal.DefaultNs, namespaceUsage)
 	rootCmd.PersistentFlags().StringVarP(&logLevel, internal.LogLevelFlag,
 		internal.LogLevelFlagShorthand, internal.DefaultLogLevel, internal.LogLevelUsage)
+	rootCmd.PersistentFlags().StringVarP(&inputFileName, inputFileFlag, inputFlagShorthand, "", inputFileUsage)
 
 	logger = logrus.New()
 	logger.SetFormatter(&logrus.TextFormatter{ForceColors: true})

--- a/cmd/preflight/cmd/root.go
+++ b/cmd/preflight/cmd/root.go
@@ -41,7 +41,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&namespace, namespaceFlag, namespaceFlagShorthand, internal.DefaultNs, namespaceUsage)
 	rootCmd.PersistentFlags().StringVarP(&logLevel, internal.LogLevelFlag,
 		internal.LogLevelFlagShorthand, internal.DefaultLogLevel, internal.LogLevelUsage)
-	rootCmd.PersistentFlags().StringVarP(&inputFileName, inputFileFlag, inputFlagShorthand, "", inputFileUsage)
+	rootCmd.PersistentFlags().StringVarP(&inputFileName, configFileFlag, configFlagShorthand, "", configFileUsage)
 
 	logger = logrus.New()
 	logger.SetFormatter(&logrus.TextFormatter{ForceColors: true})

--- a/cmd/preflight/cmd/run.go
+++ b/cmd/preflight/cmd/run.go
@@ -12,7 +12,7 @@ import (
 )
 
 // nolint:lll // ignore long line lint errors
-// runCmd represents the Run command
+// runCmd represents the run command
 var runCmd = &cobra.Command{
 	Use:   preflightRunCmdName,
 	Short: "Runs preflight checks on cluster",
@@ -31,7 +31,7 @@ var runCmd = &cobra.Command{
 
   # Cleanup the resources generated during preflight check if preflight check fails. Default is false.
   # If the preflight check is successful, then all resources are cleaned.
-  kubectl tvk-preflight run --storage-class <storage-class-name> --Cleanup-on-failure 
+  kubectl tvk-preflight run --storage-class <storage-class-name> --cleanup-on-failure 
 
   # run preflight with a particular kubeconfig file
   kubectl tvk-preflight run --storage-class <storage-class-name> --kubeconfig <kubeconfig-file-path>
@@ -42,6 +42,12 @@ var runCmd = &cobra.Command{
 
   # run preflight with a particular serviceaccount
   kubectl tvk-preflight run --storage-class <storage-class-name> --service-account-name <service account name>
+
+  # run preflight with preflight pod resource request flag
+  kubectl tvk-preflight run --storage-class <storage-class-name> --request <resource1>=<value1>,<resource2>=<value2>
+
+  # run preflight with pvc storage request flag for volume snapshot check
+  kubectl tvk-preflight run --storage-class <storage-class-name> --pvc-storage-request <storage request value>
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
@@ -78,13 +84,13 @@ var runCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(runCmd)
 
-	runCmd.Flags().StringVar(&storageClass, storageClassFlag, "", storageClassUsage)
-	runCmd.Flags().StringVar(&snapshotClass, snapshotClassFlag, "", snapshotClassUsage)
-	runCmd.Flags().StringVar(&localRegistry, localRegistryFlag, "", localRegistryUsage)
+	runCmd.Flags().StringVar(&storageClass, StorageClassFlag, "", storageClassUsage)
+	runCmd.Flags().StringVar(&snapshotClass, SnapshotClassFlag, "", snapshotClassUsage)
+	runCmd.Flags().StringVar(&localRegistry, LocalRegistryFlag, "", localRegistryUsage)
 	runCmd.Flags().StringVar(&imagePullSecret, imagePullSecFlag, "", imagePullSecUsage)
-	runCmd.Flags().StringVar(&serviceAccount, serviceAccountFlag, "", serviceAccountUsage)
-	runCmd.Flags().BoolVar(&cleanupOnFailure, cleanupOnFailureFlag, false, cleanupOnFailureUsage)
-	runCmd.Flags().StringVar(&podLimits, podLimitFlag, "", podLimitUsage)
-	runCmd.Flags().StringVar(&podRequests, podRequestFlag, "", podRequestUsage)
-	runCmd.Flags().StringVar(&pvcStorageRequest, pvcStorageRequestFlag, "", pvcStorageRequestUsage)
+	runCmd.Flags().StringVar(&serviceAccount, ServiceAccountFlag, "", serviceAccountUsage)
+	runCmd.Flags().BoolVar(&cleanupOnFailure, CleanupOnFailureFlag, false, cleanupOnFailureUsage)
+	runCmd.Flags().StringVar(&podLimits, PodLimitFlag, "", podLimitUsage)
+	runCmd.Flags().StringVar(&podRequests, PodRequestFlag, "", podRequestUsage)
+	runCmd.Flags().StringVar(&pvcStorageRequest, PVCStorageRequestFlag, "", pvcStorageRequestUsage)
 }

--- a/cmd/preflight/cmd/run.go
+++ b/cmd/preflight/cmd/run.go
@@ -12,7 +12,7 @@ import (
 )
 
 // nolint:lll // ignore long line lint errors
-// runCmd represents the run command
+// runCmd represents the Run command
 var runCmd = &cobra.Command{
 	Use:   preflightRunCmdName,
 	Short: "Runs preflight checks on cluster",
@@ -29,9 +29,9 @@ var runCmd = &cobra.Command{
   # run preflight checks with a particular log level
   kubectl tvk-preflight run --storage-class <storage-class-name> --log-level <log-level>
 
-  # cleanup the resources generated during preflight check if preflight check fails. Default is false.
+  # Cleanup the resources generated during preflight check if preflight check fails. Default is false.
   # If the preflight check is successful, then all resources are cleaned.
-  kubectl tvk-preflight run --storage-class <storage-class-name> --cleanup-on-failure 
+  kubectl tvk-preflight run --storage-class <storage-class-name> --Cleanup-on-failure 
 
   # run preflight with a particular kubeconfig file
   kubectl tvk-preflight run --storage-class <storage-class-name> --kubeconfig <kubeconfig-file-path>
@@ -49,11 +49,11 @@ var runCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err.Error())
 		}
-		err = setupLogger(preflightLogFilePrefix, cmdOps.PreflightOps.LogLevel)
+		err = setupLogger(preflightLogFilePrefix, cmdOps.Run.LogLevel)
 		if err != nil {
 			log.Fatalf("Failed to setup a logger :: %s", err.Error())
 		}
-		err = preflight.InitKubeEnv(cmdOps.PreflightOps.Kubeconfig)
+		err = preflight.InitKubeEnv(cmdOps.Run.Kubeconfig)
 		if err != nil {
 			log.Fatalf("Error initializing kubernetes clients :: %s", err.Error())
 		}
@@ -64,21 +64,14 @@ var runCmd = &cobra.Command{
 		}
 		defer logFile.Close()
 		logger.SetOutput(io.MultiWriter(colorable.NewColorableStdout(), logFile))
-		cmdOps.PreflightOps.Logger = logger
-		logRootCmdFlagsInfo(cmdOps.PreflightOps.Namespace, cmdOps.PreflightOps.Kubeconfig)
+		cmdOps.Run.Logger = logger
 
-		err = validateResourceRequirementsField()
+		err = validateRunOptions()
 		if err != nil {
 			logger.Fatalf(err.Error())
 		}
-		if cmdOps.PreflightOps.StorageClass == "" {
-			logger.Fatalf("storage-class is required, cannot be empty")
-		}
-		if cmdOps.PreflightOps.ImagePullSecret != "" && cmdOps.PreflightOps.LocalRegistry == "" {
-			logger.Fatalf("Cannot give image pull secret if local registry is not provided.\nUse --local-registry flag to provide local registry")
-		}
 
-		return cmdOps.PreflightOps.PerformPreflightChecks(context.Background())
+		return cmdOps.Run.PerformPreflightChecks(context.Background())
 	},
 }
 
@@ -91,8 +84,7 @@ func init() {
 	runCmd.Flags().StringVar(&imagePullSecret, imagePullSecFlag, "", imagePullSecUsage)
 	runCmd.Flags().StringVar(&serviceAccount, serviceAccountFlag, "", serviceAccountUsage)
 	runCmd.Flags().BoolVar(&cleanupOnFailure, cleanupOnFailureFlag, false, cleanupOnFailureUsage)
-	runCmd.Flags().StringVar(&requestMemory, requestMemoryFlag, "", requestMemoryUsage)
-	runCmd.Flags().StringVar(&limitMemory, limitMemoryFlag, "", limitMemoryUsage)
-	runCmd.Flags().StringVar(&requestCPU, requestCPUFlag, "", requestCPUUsage)
-	runCmd.Flags().StringVar(&limitCPU, limitCPUFlag, "", limitCPUUsage)
+	runCmd.Flags().StringVar(&podLimits, podLimitFlag, "", podLimitUsage)
+	runCmd.Flags().StringVar(&podRequests, podRequestFlag, "", podRequestUsage)
+	runCmd.Flags().StringVar(&pvcStorageRequest, pvcStorageRequestFlag, "", pvcStorageRequestUsage)
 }

--- a/docs/preflight/README.md
+++ b/docs/preflight/README.md
@@ -270,8 +270,8 @@ kubeconfig is pointing to in the given namespace.
 | --image-pull-secret     |             | Name of the secret for authentication while pulling the images from the local registry (Optional)
 | --service-account       |             | Name of the service account (Optional)
 | --cleanup-on-failure    |   false     | Deletes/Cleans all resources created for that particular preflight check from the cluster even if the preflight check fails. For successful execution of preflight checks, the resources are deleted from cluster by default (Optional)
-| --requests              | cpu=250m,memory=64Mi | Pod cpu and memory request for performing volume snapshot check. Memory and cpu values must be specified in a comma separated format. (Optional)
-| --limits              | cpu=500m,memory=128Mi | Pod cpu and memory limit for performing volume snapshot check. Memory and cpu values must be specified in a comma separated format. (Optional)
+| --requests              | cpu=250m,memory=64Mi | Pod cpu and memory request for DNS and volume snapshot check. Memory and cpu values must be specified in a comma separated format. (Optional)
+| --limits              | cpu=500m,memory=128Mi | Pod cpu and memory limit for DNS and volume snapshot check. Memory and cpu values must be specified in a comma separated format. (Optional)
 | --pvc-storage-request   |     1Gi     | PVC storage request for performing volume snapshot check. (Optional)
 
 #### Examples

--- a/docs/preflight/README.md
+++ b/docs/preflight/README.md
@@ -157,6 +157,39 @@ The preflight binary has three common flags to both the subcommands.
 | --namespace   | -n       | default        | Namespace of the cluster in which resources will be created, preflight checks will be performed or resources will cleaned. Default is 'default' namespace of the cluster (Optional)
 | --kubeconfig  | -k       | ~/.kube/config | kubeconfig file path (Optional)
 | --log-level   | -l       | INFO           | Logging level for the preflight check and cleanup. Logging levels are FATAL, ERROR, WARN, INFO, DEBUG (Optional)
+| --input-file  | -f       |                | yaml file path to provide inputs for run and cleanup subcommand (Optional)
+
+The inputs for running preflight checks and cleanup can be provided through a single file.
+The format of data in a file should be according to the below example:
+```yaml
+preflightOptions:
+  storageClass: <storage-classs>
+  snapshotClass: <snapshot-class>
+  namespace: <perform preflight checks in the given namespace>
+  kubeconfig: <kubeconfig file path>
+  serviceAccount: <service-account>
+  localRegistry: <complete path of the registry to pull the images from>
+  imagePullSecret: <Name of the secret while pulling images from the local registry>
+  cleanupOnFailure: <Boolean. If true cleans the preflight resources after a failed preflight run>
+  podResourceRequirements:
+    requests:
+      memory: <pod memory request for snapshot check, e.g 64Mi>
+      cpu: <pod cpu request for snapshot check, e.g 250m>
+    limits:
+      memory: <pod memory limit for snapshot check, e.g 128Mi>
+      cpu: <pod cpu limit for snapshot check, e.g 500m>
+
+cleanupOptions:
+  namespace: <clean preflight in a particular namespace>
+  kubeconfig: <kubeconfig file path>
+  logLevel: <specify logging level for cleanup>
+  cleanupMode: <specify the cleanup mode as 'all' or 'uid'>
+  uid: <This field is used when the cleanup mode is 'uid'>
+```
+- The **cleanupMode** field can have two values - *all* and *uid*. *all* mode will clean all the preflight resources present in the given namespace.
+*uid* mode will clean resources of preflight with the given *uid* in the given namespace.
+- User can override the values given in file using CLI flags.
+- The input fields should be present in the correct hierarchical order. An incorrect key or input field will result in an error and preflight checks will not performed.  
 
 #### Examples
 
@@ -185,13 +218,25 @@ kubectl tvk-preflight [sub-command] [sub-command flags] -k <kubeconfig file path
 - With `--log-level`:
 
 ```shell script
-kubectl tvk-preflight [sub command] [sub-command flags] --log-level <logging level>
+kubectl tvk-preflight [sub-command] [sub-command flags] --log-level <logging level>
 ```
 
 By using shorthand notation:
 
 ```shell script
-kubectl tvk-preflight [sub command] [sub-command flags] -l <logging level>
+kubectl tvk-preflight [sub-command] [sub-command flags] -l <logging level>
+```
+
+- With `--input-file`
+
+```shell script
+kubectl tvk-preflight [sub-command] [sub-command flags] --input-file <yaml input file path>
+```
+
+By using shorthand notation:
+
+```shell script
+kubectl tvk-preflight [sub-command] [sub-command flags] -f <yaml input file path>
 ```
 
 There are two subcommands to the preflight binary:
@@ -211,8 +256,14 @@ kubeconfig is pointing to in the given namespace.
 | --local-registry        |             | Name of the local registry from where the images will be pulled (Optional)
 | --image-pull-secret     |             | Name of the secret for authentication while pulling the images from the local registry (Optional)
 | --service-account       |             | Name of the service account (Optional)
-| --cleanup-on-failure    |   false     | Deletes/Cleans all resources created for that particular preflight check from the cluster even if the preflight check fails. For successful execution of preflight checks, the resources are deleted from cluster by default
+| --cleanup-on-failure    |   false     | Deletes/Cleans all resources created for that particular preflight check from the cluster even if the preflight check fails. For successful execution of preflight checks, the resources are deleted from cluster by default (Optional)
+| --req-memory            |   64Mi      | Pod memory request for performing volume snapshot check. This flag must be specified along-with `--lim-memory` flag. Cannot specify this flag as standalone. (Optional)
+| --req-cpu               |   250m      | Pod cpu request for performing volume snapshot check. This flag must be specified along-with `--lim-cpu` flag. Cannot specify this flag as standalone. (Optional)
+| --lim-memory            |   128Mi     | Pod memory limit for performing volume snapshot check. This flag must be specified along-with `--req-memory` flag. Cannot specify this flag as standalone. (Optional)
+| --lim-cpu               |   500m      | Pod cpu limit for performing volume snapshot check. This flag must be specified along-with `--req-cpu` flag. Cannot specify this flag as standalone. (Optional)
 
+**Note:** The only request or limit flag of a resource cannot be provided because the request value cannot be greater than the limit value for a resource.
+This restriction is applied because request and limit values of the resources are cumbersome to remember and user can more often land into a failure just because of an incorrect resource requirements input.
 
 #### Examples
 

--- a/docs/preflight/sample_file.yaml
+++ b/docs/preflight/sample_file.yaml
@@ -1,8 +1,8 @@
 run:
+  namespace: default
   storageClass: csi-gce-pd
   cleanupOnFailure: true
-  snapshotClass: default-snapshot-class
-  pvcStorageRequest: 1Gi
+  pvcStorageRequest: 2Gi
   resources:
     requests:
       memory: 64Mi
@@ -12,5 +12,6 @@ run:
       cpu: 500m
 
 cleanup:
+  namespace: default
   logLevel: info
   cleanupMode: all

--- a/docs/preflight/sample_file.yaml
+++ b/docs/preflight/sample_file.yaml
@@ -1,8 +1,8 @@
 run:
   namespace: default
-  storageClass: csi-gce-pd
+  storageClass: default
   cleanupOnFailure: true
-  pvcStorageRequest: 2Gi
+  pvcStorageRequest: 1Gi
   resources:
     requests:
       memory: 64Mi
@@ -14,4 +14,3 @@ run:
 cleanup:
   namespace: default
   logLevel: info
-  cleanupMode: all

--- a/tests/preflight/preflight_suite_test.go
+++ b/tests/preflight/preflight_suite_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,7 +35,13 @@ import (
 
 const (
 	defaultTestStorageClass  = "csi-gce-pd"
+	longHornStorageClass     = "longhorn"
 	defaultTestSnapshotClass = "longhorn"
+	defaultPodReqMemory      = "64Mi"
+	defaultPodLimMemory      = "128Mi"
+	defaultPodReqCPU         = "250m"
+	memory256                = "256Mi"
+	cpu400                   = "400m"
 
 	dnsPodNamePrefix = "test-dns-pod-"
 	dnsContainerName = "test-dnsutils"
@@ -43,6 +50,7 @@ const (
 	invalidVolSnapDriver   = "invalid.csi.k8s.io"
 	preflightSAName        = "preflight-sa"
 	preflightKubeConf      = "preflight_test_config"
+	flagNamespace          = "preflight-flag-ns"
 	kubeconfigEnv          = "KUBECONFIG"
 	filePermission         = 0644
 
@@ -60,12 +68,16 @@ var (
 	storageClassFlag     = "--storage-class"
 	snapshotClassFlag    = "--volume-snapshot-class"
 	localRegistryFlag    = "--local-registry"
-	imagePullSecFlag     = "--image-pull-secret"
 	serviceAccountFlag   = "--service-account"
 	cleanupOnFailureFlag = "--cleanup-on-failure"
 	namespaceFlag        = "--namespace"
 	kubeconfigFlag       = "--kubeconfig"
 	logLevelFlag         = "--log-level"
+	inputFileFlag        = "--input-file"
+	limitCPUFlag         = "--lim-cpu"
+	limitMemoryFlag      = "--lim-memory"
+	reqCPUFlag           = "--req-cpu"
+	reqMemoryFlag        = "--req-memory"
 
 	preflightLogFilePrefix    = "preflight-"
 	cleanupLogFilePrefix      = "preflight_cleanup-"
@@ -77,9 +89,15 @@ var (
 	invalidNamespace          = "invalid-ns"
 	invalidKubeConfFilename   = path.Join([]string{".", "invalid_kc_file"}...)
 	invalidKubeConfFileData   = "invalid data"
+	invalidYamlFilePath       = "invalid_path.yaml"
+	invalidKeyYamlFileName    = "invalid_key_file.yaml"
 	defaultTestNs             = testutils.GetInstallNamespace()
-
-	kubeConfPath = os.Getenv(kubeconfigEnv)
+	permYamlFile              = "file_permission.yaml"
+	cleanupUIDInputYamlFile   = "cleanup_uid_input.yaml"
+	cleanupUIDFileInputData   = strings.Join([]string{"cleanupOptions:",
+		"  logLevel: info", "  cleanupMode: uid"}, "\n")
+	cleanupAllInputYamlFile = "cleanup_all_input.yaml"
+	kubeConfPath            = os.Getenv(kubeconfigEnv)
 
 	distDir                 = "dist"
 	preflightDir            = "preflight_linux_amd64"
@@ -88,6 +106,8 @@ var (
 	preflightBinaryDir      = filepath.Join(projectRoot, distDir, preflightDir)
 	preflightBinaryName     = "preflight"
 	preflightBinaryFilePath = filepath.Join(preflightBinaryDir, preflightBinaryName)
+	testDataDirRelPath      = filepath.Join(projectRoot, "tests", "preflight", "test-data")
+	testFileInputName       = "preflight_file_input.yaml"
 
 	flagsMap = map[string]string{
 		storageClassFlag:     defaultTestStorageClass,

--- a/tests/preflight/preflight_test.go
+++ b/tests/preflight/preflight_test.go
@@ -6,17 +6,18 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/trilioData/tvk-plugins/tools/preflight"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/trilioData/tvk-plugins/internal/utils/shell"
-	"github.com/trilioData/tvk-plugins/tools/preflight"
 )
 
 var _ = Describe("Preflight Tests", func() {
@@ -37,7 +38,7 @@ var _ = Describe("Preflight Tests", func() {
 				copyMap(flagsMap, inputFlags)
 				inputFlags[storageClassFlag] = invalidStorageClassName
 				cmdOut, err = runPreflightChecks(inputFlags)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(BeNil())
 
 				Expect(cmdOut.Out).To(
 					ContainSubstring(fmt.Sprintf("Preflight check for SnapshotClass failed :: "+
@@ -70,7 +71,7 @@ var _ = Describe("Preflight Tests", func() {
 				copyMap(flagsMap, inputFlags)
 				inputFlags[snapshotClassFlag] = invalidSnapshotClassName
 				cmdOut, err = runPreflightChecks(inputFlags)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(BeNil())
 
 				Expect(cmdOut.Out).To(ContainSubstring(
 					fmt.Sprintf("volume snapshot class %s not found on cluster :: "+
@@ -90,7 +91,7 @@ var _ = Describe("Preflight Tests", func() {
 				copyMap(flagsMap, inputFlags)
 				inputFlags[snapshotClassFlag] = sampleVolSnapClassName
 				cmdOut, err = runPreflightChecks(inputFlags)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(BeNil())
 
 				Expect(cmdOut.Out).To(ContainSubstring(
 					fmt.Sprintf("Preflight check for SnapshotClass failed :: volume snapshot class - %s "+
@@ -107,7 +108,7 @@ var _ = Describe("Preflight Tests", func() {
 				copyMap(flagsMap, inputFlags)
 				inputFlags[localRegistryFlag] = invalidLocalRegistryName
 				cmdOut, err = runPreflightChecks(inputFlags)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(BeNil())
 
 				Expect(cmdOut.Out).To(
 					MatchRegexp("(DNS pod - dnsutils-)([a-z]{6})( hasn't reached into ready state)"))
@@ -117,7 +118,7 @@ var _ = Describe("Preflight Tests", func() {
 					MatchRegexp("(Preflight check for volume snapshot and restore failed :: pod source-pod-)" +
 						"([a-z]{6})( hasn't reached into ready state)"))
 
-				nonCRUDPreflightCheckAssertion(inputFlags, cmdOut.Out)
+				nonCRUDPreflightCheckAssertion(inputFlags[storageClassFlag], "", cmdOut.Out)
 			})
 		})
 
@@ -140,7 +141,7 @@ var _ = Describe("Preflight Tests", func() {
 				copyMap(flagsMap, inputFlags)
 				inputFlags[serviceAccountFlag] = invalidServiceAccountName
 				cmdOut, err = runPreflightChecks(inputFlags)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(BeNil())
 
 				Expect(cmdOut.Out).
 					To(MatchRegexp(fmt.Sprintf("(Preflight check for DNS resolution failed :: pods \"dnsutils-)([a-z]{6}\")"+
@@ -156,7 +157,7 @@ var _ = Describe("Preflight Tests", func() {
 						"(error looking up service account %s/%s: serviceaccount \"%s\" not found)",
 						defaultTestNs, invalidServiceAccountName, invalidServiceAccountName)))
 
-				nonCRUDPreflightCheckAssertion(inputFlags, cmdOut.Out)
+				nonCRUDPreflightCheckAssertion(inputFlags[storageClassFlag], "", cmdOut.Out)
 			})
 		})
 
@@ -181,7 +182,7 @@ var _ = Describe("Preflight Tests", func() {
 				delete(inputFlags, cleanupOnFailureFlag)
 				inputFlags[localRegistryFlag] = invalidLocalRegistryName
 				cmdOut, err = runPreflightChecks(inputFlags)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(BeNil())
 
 				By("Preflight pods should not be removed from cluster")
 				Consistently(func() int {
@@ -222,9 +223,9 @@ var _ = Describe("Preflight Tests", func() {
 				copyMap(flagsMap, inputFlags)
 				inputFlags[namespaceFlag] = invalidNamespace
 				cmdOut, err = runPreflightChecks(inputFlags)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(BeNil())
 
-				nonCRUDPreflightCheckAssertion(inputFlags, cmdOut.Out)
+				nonCRUDPreflightCheckAssertion(inputFlags[storageClassFlag], "", cmdOut.Out)
 				Expect(cmdOut.Out).To(ContainSubstring(fmt.Sprintf(
 					" Preflight check for DNS resolution failed :: namespaces \"%s\" not found", inputFlags[namespaceFlag])))
 				Expect(cmdOut.Out).To(ContainSubstring(fmt.Sprintf(
@@ -236,7 +237,7 @@ var _ = Describe("Preflight Tests", func() {
 				args := []string{"run", storageClassFlag, defaultTestStorageClass, namespaceFlag, "", cleanupOnFailureFlag}
 				cmd := exec.Command(preflightBinaryFilePath, args...)
 				output, err = cmd.CombinedOutput()
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(BeNil())
 
 				Expect(string(output)).To(ContainSubstring("Preflight check for DNS resolution failed :: " +
 					"an empty namespace may not be set during creation"))
@@ -294,6 +295,169 @@ var _ = Describe("Preflight Tests", func() {
 				assertSuccessfulPreflightChecks(flagsMap, string(output))
 			})
 		})
+
+		Context("Preflight run command, volume snapshot pod resource requests and limits flag testcase", func() {
+			It("Pods for volume snapshot check should use CPU and memory resources according to the given flag values", func() {
+				inputFlags := make(map[string]string)
+				copyMap(flagsMap, inputFlags)
+				inputFlags[reqCPUFlag] = "300m"
+				inputFlags[reqMemoryFlag] = defaultPodLimMemory
+				inputFlags[limitCPUFlag] = "600m"
+				inputFlags[limitMemoryFlag] = memory256
+				cmdOut, err = runPreflightChecks(inputFlags)
+				Expect(err).To(BeNil())
+
+				Expect(cmdOut.Out).To(ContainSubstring(
+					fmt.Sprintf("Volume snapshot pods resource requests: memory - %s, cpu - 300m", defaultPodLimMemory)))
+				Expect(cmdOut.Out).To(ContainSubstring(
+					fmt.Sprintf("Volume snapshot pods resource limits: memory - %s, cpu - 600m", memory256)))
+				assertSuccessfulPreflightChecks(inputFlags, cmdOut.Out)
+			})
+
+			It("Should not perform preflight checks if volume snapshot pod request memory is greater than limit memory", func() {
+				inputFlags := make(map[string]string)
+				copyMap(flagsMap, inputFlags)
+				inputFlags[reqMemoryFlag] = "128Mi"
+				inputFlags[limitMemoryFlag] = defaultPodReqMemory
+				cmdOut, err = runPreflightChecks(inputFlags)
+				Expect(err).ToNot(BeNil())
+
+				Expect(cmdOut.Out).To(ContainSubstring("request memory cannot be greater than limit memory"))
+			})
+
+			It("Should not perform preflight checks if volume snapshot pod request cpu is greater than limit cpu", func() {
+				inputFlags := make(map[string]string)
+				copyMap(flagsMap, inputFlags)
+				inputFlags[reqCPUFlag] = "500m"
+				inputFlags[limitCPUFlag] = "250m"
+				cmdOut, err = runPreflightChecks(inputFlags)
+				Expect(err).ToNot(BeNil())
+
+				Expect(cmdOut.Out).To(ContainSubstring("request CPU cannot be greater than limit CPU"))
+			})
+
+			It("Should not perform preflight checks if only the memory request requirement is specified", func() {
+				inputFlags := make(map[string]string)
+				copyMap(flagsMap, inputFlags)
+				inputFlags[reqMemoryFlag] = "32Mi"
+				cmdOut, err = runPreflightChecks(inputFlags)
+				Expect(err).ToNot(BeNil())
+
+				Expect(cmdOut.Out).To(ContainSubstring(
+					"non-zero memory requirement must be specified or skipped for both requests and limits. " +
+						"Memory requirement for only request or limit should not be specified"))
+			})
+
+			It("Should not perform preflight checks if only the memory limit requirement is specified", func() {
+				inputFlags := make(map[string]string)
+				copyMap(flagsMap, inputFlags)
+				inputFlags[limitMemoryFlag] = "64Mi"
+				cmdOut, err = runPreflightChecks(inputFlags)
+				Expect(err).ToNot(BeNil())
+
+				Expect(cmdOut.Out).To(ContainSubstring(
+					"non-zero memory requirement must be specified or skipped for both requests and limits. " +
+						"Memory requirement for only request or limit should not be specified"))
+			})
+
+			It("Should not perform preflight checks if only the cpu request requirement is specified", func() {
+				inputFlags := make(map[string]string)
+				copyMap(flagsMap, inputFlags)
+				inputFlags[reqCPUFlag] = "200m"
+				cmdOut, err = runPreflightChecks(inputFlags)
+				Expect(err).ToNot(BeNil())
+
+				Expect(cmdOut.Out).To(ContainSubstring(
+					"non-zero CPU requirement must be specified or skipped for both requests and limits. " +
+						"CPU requirement for only request or limit should not be specified"))
+			})
+
+			It("Should not perform preflight checks if only the cpu limit requirement is specified", func() {
+				inputFlags := make(map[string]string)
+				copyMap(flagsMap, inputFlags)
+				inputFlags[limitCPUFlag] = cpu400
+				cmdOut, err = runPreflightChecks(inputFlags)
+				Expect(err).ToNot(BeNil())
+
+				Expect(cmdOut.Out).To(ContainSubstring(
+					"non-zero CPU requirement must be specified or skipped for both requests and limits. " +
+						"CPU requirement for only request or limit should not be specified"))
+			})
+		})
+
+		Context("Preflight run command, input file flag test cases", func() {
+			It("Should perform preflight checks when inputs are provided from a yaml file", func() {
+				yamlFilePath := filepath.Join(testDataDirRelPath, testFileInputName)
+				inputFlags := make(map[string]string)
+				inputFlags[inputFileFlag] = yamlFilePath
+				cmdOut, err = runPreflightChecks(inputFlags)
+				Expect(err).To(BeNil())
+
+				nonCRUDPreflightCheckAssertion(defaultTestStorageClass, defaultTestSnapshotClass, cmdOut.Out)
+				assertDNSResolutionCheckSuccess(cmdOut.Out)
+				assertVolumeSnapshotCheckSuccess(cmdOut.Out)
+			})
+
+			It("Should perform preflight checks with with file inputs overridden by CLI flag inputs", func() {
+				yamlFilePath := filepath.Join(testDataDirRelPath, testFileInputName)
+				createNamespace(flagNamespace)
+				defer deleteNamespace(flagNamespace)
+				inputFlags := make(map[string]string)
+				inputFlags[inputFileFlag] = yamlFilePath
+				inputFlags[namespaceFlag] = flagNamespace
+				inputFlags[storageClassFlag] = longHornStorageClass
+				inputFlags[reqCPUFlag] = cpu400
+				inputFlags[limitMemoryFlag] = "256Mi"
+				cmdOut, err = runPreflightChecks(inputFlags)
+				Expect(err).To(BeNil())
+
+				Expect(cmdOut.Out).To(ContainSubstring(
+					fmt.Sprintf("Volume snapshot pods resource requests: memory - %s, cpu - %s",
+						defaultPodReqMemory, cpu400)))
+				Expect(cmdOut.Out).To(ContainSubstring(
+					fmt.Sprintf("Volume snapshot pods resource limits: memory - %s, cpu - %s",
+						defaultPodReqCPU, defaultPodLimMemory)))
+				assertSuccessfulPreflightChecks(inputFlags, cmdOut.Out)
+			})
+
+			It("Should not perform preflight checks if file does not exist at the given path", func() {
+				inputFlags := make(map[string]string)
+				inputFlags[inputFileFlag] = invalidYamlFilePath
+				cmdOut, err = runPreflightChecks(inputFlags)
+				Expect(err).ToNot(BeNil())
+
+				Expect(cmdOut.Out).To(ContainSubstring(fmt.Sprintf(
+					"failed to read preflight input from file :: open %s: no such file or directory", invalidYamlFilePath)))
+			})
+
+			It("Should not be able to perform preflight checks if file read permission is not present", func() {
+				var file *os.File
+				file, err = os.OpenFile(permYamlFile, os.O_CREATE, 0000)
+				Expect(err).To(BeNil())
+				file.Close()
+				inputFlags := make(map[string]string)
+				inputFlags[inputFileFlag] = permYamlFile
+				cmdOut, err = runPreflightChecks(inputFlags)
+				Expect(err).ToNot(BeNil())
+
+				Expect(cmdOut.Out).To(ContainSubstring(fmt.Sprintf(
+					"failed to read preflight input from file :: open %s: permission denied", permYamlFile)))
+
+				err = os.Remove(permYamlFile)
+				Expect(err).To(BeNil())
+			})
+
+			It("Should not perform preflight checks if file contains invalid keys or invalid key hierarchy", func() {
+				yamlFilePath := filepath.Join([]string{testDataDirRelPath, invalidKeyYamlFileName}...)
+				inputFlags := make(map[string]string)
+				inputFlags[inputFileFlag] = yamlFilePath
+				cmdOut, err = runPreflightChecks(inputFlags)
+				Expect(err).ToNot(BeNil())
+
+				Expect(cmdOut.Out).To(ContainSubstring("failed to read preflight input from file :: " +
+					"error unmarshaling JSON: while decoding JSON: json: unknown field"))
+			})
+		})
 	})
 
 	Context("Preflight cleanup command test-cases", func() {
@@ -306,37 +470,71 @@ var _ = Describe("Preflight Tests", func() {
 				cmdOut, err = runCleanupForAllPreflightResources()
 				Expect(err).To(BeNil())
 
-				Expect(cmdOut.Out).To(ContainSubstring("All preflight resources cleaned"))
+				assertSuccessCleanupAll(cmdOut.Out)
+			})
+		})
 
-				By("All preflight pods should be removed from cluster")
-				Eventually(func() int {
-					podList := unstructured.UnstructuredList{}
-					podList.SetGroupVersionKind(podGVK)
-					err = runtimeClient.List(ctx, &podList,
-						client.MatchingLabels(getPreflightResourceLabels("")), client.InNamespace(defaultTestNs))
-					Expect(err).To(BeNil())
-					return len(podList.Items)
-				}, timeout, interval).Should(Equal(0))
+		Context("Cleanup resources according to preflight UID in a particular namespace", func() {
 
-				By("All preflight PVCs should be removed from cluster")
-				Eventually(func() int {
-					pvcList := unstructured.UnstructuredList{}
-					pvcList.SetGroupVersionKind(pvcGVK)
-					err = runtimeClient.List(ctx, &pvcList,
-						client.MatchingLabels(getPreflightResourceLabels("")), client.InNamespace(defaultTestNs))
-					Expect(err).To(BeNil())
-					return len(pvcList.Items)
-				}, timeout, interval).Should(Equal(0))
+			It("Should clean pods, PVCs and volume snapshots of preflight check for specific uid", func() {
+				var uid = createPreflightResourcesForCleanup()
+				cmdOut, err = runCleanupWithUID(uid)
+				Expect(err).To(BeNil())
 
-				By("All preflight volume snapshots should be removed from the cluster")
-				Eventually(func() int {
-					snapshotList := unstructured.UnstructuredList{}
-					snapshotList.SetGroupVersionKind(snapshotGVK)
-					err = runtimeClient.List(ctx, &snapshotList,
-						client.MatchingLabels(getPreflightResourceLabels("")), client.InNamespace(defaultTestNs))
+				assertSuccessCleanupUID(uid, cmdOut.Out)
+			})
+		})
+
+		Context("Cleanup resources according to the input given in yaml file", func() {
+			It("Should cleanup resources with a particular UID when cleanup inputs are given through a file "+
+				"and cleanup mode is 'uid'", func() {
+
+				var file *os.File
+				uid := createPreflightResourcesForCleanup()
+				yamlFilePath := filepath.Join(testDataDirRelPath, cleanupUIDInputYamlFile)
+				file, err = os.OpenFile(yamlFilePath, os.O_CREATE|os.O_WRONLY, 0644)
+				defer func() {
+					err = file.Close()
 					Expect(err).To(BeNil())
-					return len(snapshotList.Items)
-				}, timeout, interval).Should(Equal(0))
+				}()
+				cleanupUIDFileInputData += strings.Join([]string{"\n", fmt.Sprintf("  uid: %s", uid)}, "")
+				_, err = file.Write([]byte(cleanupUIDFileInputData))
+				Expect(err).To(BeNil())
+
+				cmd := fmt.Sprintf("%s cleanup -f %s", preflightBinaryFilePath, yamlFilePath)
+				log.Infof("Preflight cleanup CMD [%s]", cmd)
+				cmdOut, err = shell.RunCmd(cmd)
+				log.Infof("Preflight binary cleanup execution output: %s", cmdOut.Out)
+
+				assertSuccessCleanupUID(uid, cmdOut.Out)
+
+				err = os.Remove(yamlFilePath)
+				Expect(err).To(BeNil())
+			})
+
+			It("Should cleanup all preflight resources when cleanup inputs are given through  file "+
+				"and cleanup mode is 'all'", func() {
+				_ = createPreflightResourcesForCleanup()
+				_ = createPreflightResourcesForCleanup()
+				_ = createPreflightResourcesForCleanup()
+				yamlFilePath := filepath.Join(testDataDirRelPath, cleanupAllInputYamlFile)
+				cmd := fmt.Sprintf("%s cleanup -f %s", preflightBinaryFilePath, yamlFilePath)
+				log.Infof("Preflight cleanup CMD [%s]", cmd)
+				cmdOut, err = shell.RunCmd(cmd)
+				log.Infof("Preflight binary cleanup execution output: %s", cmdOut.Out)
+
+				assertSuccessCleanupAll(cmdOut.Out)
+			})
+
+			It("Should not perform cleanup if invalid input file path is given", func() {
+				cmd := fmt.Sprintf("%s cleanup -f %s", preflightBinaryFilePath, invalidYamlFilePath)
+				log.Infof("Preflight cleanup CMD [%s]", cmd)
+				cmdOut, err = shell.RunCmd(cmd)
+				log.Infof("Preflight binary cleanup execution output: %s", cmdOut.Out)
+
+				Expect(cmdOut.Out).To(ContainSubstring(
+					fmt.Sprintf("preflight command execution failed - open %s: no such file or directory",
+						invalidYamlFilePath)))
 			})
 		})
 
@@ -405,33 +603,10 @@ func runPreflightChecks(flagsMap map[string]string) (cmdOut *shell.CmdOut, err e
 	var flags string
 
 	for key, val := range flagsMap {
-		switch key {
-		case storageClassFlag:
-			flags = strings.Join([]string{flags, storageClassFlag, val}, spaceSeparator)
-
-		case namespaceFlag:
-			flags = strings.Join([]string{flags, namespaceFlag, val}, spaceSeparator)
-
-		case snapshotClassFlag:
-			flags = strings.Join([]string{flags, snapshotClassFlag, val}, spaceSeparator)
-
-		case localRegistryFlag:
-			flags = strings.Join([]string{flags, localRegistryFlag, val}, spaceSeparator)
-
-		case imagePullSecFlag:
-			flags = strings.Join([]string{flags, imagePullSecFlag, val}, spaceSeparator)
-
-		case serviceAccountFlag:
-			flags = strings.Join([]string{flags, serviceAccountFlag, val}, spaceSeparator)
-
-		case cleanupOnFailureFlag:
+		if key == cleanupOnFailureFlag {
 			flags = strings.Join([]string{flags, cleanupOnFailureFlag}, spaceSeparator)
-
-		case logLevelFlag:
-			flags = strings.Join([]string{flags, logLevelFlag, val}, spaceSeparator)
-
-		case kubeconfigFlag:
-			flags = strings.Join([]string{flags, kubeconfigFlag, val}, spaceSeparator)
+		} else {
+			flags = strings.Join([]string{flags, key, val}, spaceSeparator)
 		}
 	}
 

--- a/tests/preflight/test-data/cleanup_all_input.yaml
+++ b/tests/preflight/test-data/cleanup_all_input.yaml
@@ -1,3 +1,0 @@
-cleanupOptions:
-  logLevel: info
-  cleanupMode: all

--- a/tests/preflight/test-data/cleanup_all_input.yaml
+++ b/tests/preflight/test-data/cleanup_all_input.yaml
@@ -1,0 +1,3 @@
+cleanupOptions:
+  logLevel: info
+  cleanupMode: all

--- a/tests/preflight/test-data/invalid_key_file.yaml
+++ b/tests/preflight/test-data/invalid_key_file.yaml
@@ -1,0 +1,11 @@
+preflightOptions:
+  storageClass: csi-gce-pd
+  cleanupOnFailure: true
+  invalidKey: invalidValue
+  podResourceRequirements:
+    requests:
+      memory: 32Mi
+      cpu: 250m
+    limits:
+      memory: 96Mi
+      cpu: 500m

--- a/tests/preflight/test-data/invalid_key_file.yaml
+++ b/tests/preflight/test-data/invalid_key_file.yaml
@@ -1,4 +1,4 @@
-preflightOptions:
+run:
   storageClass: csi-gce-pd
   cleanupOnFailure: true
   invalidKey: invalidValue

--- a/tests/preflight/test-data/preflight_file_input.yaml
+++ b/tests/preflight/test-data/preflight_file_input.yaml
@@ -1,0 +1,15 @@
+preflightOptions:
+  storageClass: csi-gce-pd
+  cleanupOnFailure: true
+  snapshotClass: longhorn
+  podResourceRequirements:
+    requests:
+      memory: 64Mi
+      cpu: 250m
+    limits:
+      memory: 128Mi
+      cpu: 500m
+
+cleanupOptions:
+  logLevel: info
+  cleanupMode: all

--- a/tests/preflight/test_helper.go
+++ b/tests/preflight/test_helper.go
@@ -3,16 +3,17 @@ package preflighttest
 // nolint // ignore dot import lint errors
 import (
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/trilioData/tvk-plugins/cmd/preflight/cmd"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/trilioData/tvk-plugins/internal"
 	"github.com/trilioData/tvk-plugins/tools/preflight"
@@ -140,7 +141,7 @@ func assertVolumeSnapshotCheckSuccess(outputLog string) {
 
 func assertPVCStorageRequestCheckSuccess(outputLog, pvcStorageRequest string) {
 	if pvcStorageRequest == "" {
-		Expect(outputLog).To(ContainSubstring(fmt.Sprintf("PVC STORAGE REQUEST=\"%s\"", defaultPVCStorageRequest)))
+		Expect(outputLog).To(ContainSubstring(fmt.Sprintf("PVC STORAGE REQUEST=\"%s\"", cmd.DefaultPVCStorage)))
 	} else {
 		Expect(outputLog).To(ContainSubstring(fmt.Sprintf("PVC STORAGE REQUEST=\"%s\"", pvcStorageRequest)))
 	}

--- a/tools/preflight/cleanup.go
+++ b/tools/preflight/cleanup.go
@@ -13,6 +13,8 @@ import (
 
 type CleanupOptions struct {
 	CommonOptions
+	CleanupMode string `json:"cleanupMode"`
+	UID         string `json:"uid"`
 }
 
 // CleanupPreflightResources cleans the preflight resources.
@@ -31,6 +33,9 @@ func (o *CleanupOptions) CleanupPreflightResources(ctx context.Context, uid stri
 	}
 	if uid != "" {
 		resLabels[LabelPreflightRunKey] = uid
+	}
+	if o.CleanupMode == uidCleanupMode {
+		resLabels[LabelPreflightRunKey] = o.UID
 	}
 	for _, gvk := range gvkList {
 		var resList = unstructured.UnstructuredList{}

--- a/tools/preflight/cleanup.go
+++ b/tools/preflight/cleanup.go
@@ -12,18 +12,34 @@ import (
 )
 
 type CleanupOptions struct {
-	CommonOptions
 	CleanupMode string `json:"cleanupMode"`
 	UID         string `json:"uid"`
+}
+
+type Cleanup struct {
+	CleanupOptions
+	CommonOptions
+}
+
+func (co *Cleanup) logCleanupOptions() {
+	co.Logger.Infoln("====PREFLIGHT CLEANUP OPTIONS====")
+	co.CommonOptions.logCommonOptions()
+	co.Logger.Infof("CLEANUP-MODE=\"%s\"", co.CleanupMode)
+	co.Logger.Infof("UID=\"%s\"", co.UID)
+	co.Logger.Infoln("====PREFLIGHT CLEANUP OPTIONS END====")
 }
 
 // CleanupPreflightResources cleans the preflight resources.
 // if uid is provided then preflight resources of particular uid are cleaned.
 // if uid is empty then all preflight resources are cleaned.
-func (o *CleanupOptions) CleanupPreflightResources(ctx context.Context, uid string) error {
-	o.Logger.Infoln("Cleaning all preflight resources")
-	var allSuccess = true
-	var err error
+func (co *Cleanup) CleanupPreflightResources(ctx context.Context) error {
+	co.logCleanupOptions()
+	co.Logger.Infoln("Cleaning all preflight resources")
+	var (
+		allSuccess = true
+		err        error
+		deleteNs   = internal.DefaultNs
+	)
 	gvkList, err := getCleanupResourceGVKList()
 	if err != nil {
 		return err
@@ -31,43 +47,44 @@ func (o *CleanupOptions) CleanupPreflightResources(ctx context.Context, uid stri
 	resLabels := map[string]string{
 		LabelTrilioKey: LabelTvkPreflightValue,
 	}
-	if uid != "" {
-		resLabels[LabelPreflightRunKey] = uid
+	if co.Namespace != "" {
+		deleteNs = co.Namespace
 	}
-	if o.CleanupMode == uidCleanupMode {
-		resLabels[LabelPreflightRunKey] = o.UID
+
+	if co.CleanupMode == uidCleanupMode {
+		resLabels[LabelPreflightRunKey] = co.UID
 	}
 	for _, gvk := range gvkList {
 		var resList = unstructured.UnstructuredList{}
 		resList.SetGroupVersionKind(gvk)
-		if err = runtimeClient.List(ctx, &resList, client.MatchingLabels(resLabels)); err != nil {
-			o.Logger.Errorf("Error fetching %s(s)  :: %s\n", gvk.Kind, err.Error())
+		if err = runtimeClient.List(ctx, &resList, client.MatchingLabels(resLabels), client.InNamespace(deleteNs)); err != nil {
+			co.Logger.Errorf("Error fetching %s(s)  :: %s\n", gvk.Kind, err.Error())
 			allSuccess = false
 			continue
 		}
 		for _, res := range resList.Items {
 			res := res
-			err = o.cleanResource(ctx, &res)
+			err = co.cleanResource(ctx, &res)
 			if err != nil {
 				allSuccess = false
-				o.Logger.Errorf("problem occurred deleting %s - %s :: %s", res.GetKind(), res.GetName(), err.Error())
+				co.Logger.Errorf("problem occurred deleting %s - %s :: %s", res.GetKind(), res.GetName(), err.Error())
 			}
 		}
 	}
 	if allSuccess {
-		o.Logger.Infoln("All preflight resources cleaned")
+		co.Logger.Infoln("All preflight resources cleaned")
 		return nil
 	}
 
 	return errors.New("deletion of some resources failed in cleanup process")
 }
 
-func (o *CleanupOptions) cleanResource(ctx context.Context, resource *unstructured.Unstructured) error {
+func (co *Cleanup) cleanResource(ctx context.Context, resource *unstructured.Unstructured) error {
 	var err error
-	o.Logger.Infof("Cleaning %s - %s", resource.GetKind(), resource.GetName())
-	err = deleteK8sResourceWithForceTimeout(ctx, resource, o.Logger)
+	co.Logger.Infof("Cleaning %s - %s", resource.GetKind(), resource.GetName())
+	err = deleteK8sResourceWithForceTimeout(ctx, resource, co.Logger)
 	if err != nil {
-		o.Logger.Errorf("%s Error cleaning %s - %s :: %s\n",
+		co.Logger.Errorf("%s Error cleaning %s - %s :: %s\n",
 			cross, resource.GetKind(), resource.GetName(), err.Error())
 	}
 	return err

--- a/tools/preflight/cleanup.go
+++ b/tools/preflight/cleanup.go
@@ -12,8 +12,7 @@ import (
 )
 
 type CleanupOptions struct {
-	CleanupMode string `json:"cleanupMode"`
-	UID         string `json:"uid"`
+	UID string `json:"uid,omitempty"`
 }
 
 type Cleanup struct {
@@ -24,7 +23,6 @@ type Cleanup struct {
 func (co *Cleanup) logCleanupOptions() {
 	co.Logger.Infoln("====PREFLIGHT CLEANUP OPTIONS====")
 	co.CommonOptions.logCommonOptions()
-	co.Logger.Infof("CLEANUP-MODE=\"%s\"", co.CleanupMode)
 	co.Logger.Infof("UID=\"%s\"", co.UID)
 	co.Logger.Infoln("====PREFLIGHT CLEANUP OPTIONS END====")
 }
@@ -51,7 +49,7 @@ func (co *Cleanup) CleanupPreflightResources(ctx context.Context) error {
 		deleteNs = co.Namespace
 	}
 
-	if co.CleanupMode == uidCleanupMode {
+	if co.UID != "" {
 		resLabels[LabelPreflightRunKey] = co.UID
 	}
 	for _, gvk := range gvkList {

--- a/tools/preflight/helper.go
+++ b/tools/preflight/helper.go
@@ -77,8 +77,6 @@ const (
 
 	execTimeoutDuration       = 3 * time.Minute
 	deletionGracePeriod int64 = 5
-
-	uidCleanupMode = "uid"
 )
 
 var (
@@ -115,9 +113,9 @@ var (
 )
 
 type CommonOptions struct {
-	Kubeconfig string `yaml:"kubeconfig"`
-	Namespace  string `yaml:"namespace"`
-	LogLevel   string `yaml:"logLevel'"`
+	Kubeconfig string `yaml:"kubeconfig,omitempty"`
+	Namespace  string `yaml:"namespace,omitempty"`
+	LogLevel   string `yaml:"logLevel,omitempty"`
 	Logger     *logrus.Logger
 }
 
@@ -527,6 +525,7 @@ func deleteK8sResourceWithForceTimeout(ctx context.Context, obj client.Object, l
 		logger.Warnf("problem occurred while removing finalizers of %s - %s :: %s",
 			obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err.Error())
 	}
+
 	err = runtimeClient.Delete(ctx, obj, client.DeleteOption(client.GracePeriodSeconds(deletionGracePeriod)))
 	if err != nil {
 		return fmt.Errorf("problem occurred deleting %s - %s :: %s", obj.GetName(), obj.GetNamespace(), err.Error())

--- a/tools/preflight/preflight.go
+++ b/tools/preflight/preflight.go
@@ -25,13 +25,13 @@ import (
 
 // RunOptions input options required for running preflight.
 type RunOptions struct {
-	StorageClass                string            `json:"storageClass"`
-	SnapshotClass               string            `json:"snapshotClass"`
-	LocalRegistry               string            `json:"localRegistry"`
-	ImagePullSecret             string            `json:"imagePullSecret"`
-	ServiceAccountName          string            `json:"serviceAccount"`
-	PerformCleanupOnFail        bool              `json:"cleanupOnFailure"`
-	PVCStorageRequest           resource.Quantity `json:"pvcStorageRequest"`
+	StorageClass                string            `json:"storageClass,omitempty"`
+	SnapshotClass               string            `json:"snapshotClass,omitempty"`
+	LocalRegistry               string            `json:"localRegistry,omitempty"`
+	ImagePullSecret             string            `json:"imagePullSecret,omitempty"`
+	ServiceAccountName          string            `json:"serviceAccount,omitempty"`
+	PerformCleanupOnFail        bool              `json:"cleanupOnFailure,omitempty"`
+	PVCStorageRequest           resource.Quantity `json:"pvcStorageRequest,omitempty"`
 	corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
@@ -186,8 +186,7 @@ func (o *Run) PerformPreflightChecks(ctx context.Context) error {
 			Logger:     o.Logger,
 		},
 		CleanupOptions: CleanupOptions{
-			CleanupMode: uidCleanupMode,
-			UID:         resNameSuffix,
+			UID: resNameSuffix,
 		},
 	}
 	if !preflightStatus {


### PR DESCRIPTION
Able to read input for preflight run and cleanup through a yaml file.
Can override the inputs of the file through CLI flags.

Added 3 flags of resources requirements during preflight run:
1. --requests: user can specify cpu and memory requests for all pods
2. --limits: user can specify cpu and memory limits for all pods
3. --pvc-storage-request: PVC storage requirement request for volume snapshot check.

Integration tests are added.
