### PR TITLE
:seedling: TK-4939 Preflight Plugin : Add Support for Pod Scheduling

### DIFF
--- a/cmd/preflight/cmd/cleanup.go
+++ b/cmd/preflight/cmd/cleanup.go
@@ -18,7 +18,7 @@ var cleanupCmd = &cobra.Command{
 	Long: `Cleans-up the resources that were created during preflight checks.
 If uid flag is not specified then all preflight resources created till date are deleted.`,
 	Example: ` # clean preflight resources with a particular uid
-  kubectl tvk-preflight cleanup --uid <preflight Run uid> --namespace <namespace>
+  kubectl tvk-preflight cleanup --uid <preflight run uid> --namespace <namespace>
 
   # clean all preflight resources created till date
   kubectl tvk-preflight cleanup --namespace <namespace>

--- a/cmd/preflight/cmd/cleanup.go
+++ b/cmd/preflight/cmd/cleanup.go
@@ -18,13 +18,13 @@ var cleanupCmd = &cobra.Command{
 	Long: `Cleans-up the resources that were created during preflight checks.
 If uid flag is not specified then all preflight resources created till date are deleted.`,
 	Example: ` # clean preflight resources with a particular uid
-  kubectl tvk-preflight cleanup --uid <preflight run uid> --namespace <namespace>
+  kubectl tvk-preflight cleanup --uid <preflight Run uid> --namespace <namespace>
 
   # clean all preflight resources created till date
   kubectl tvk-preflight cleanup --namespace <namespace>
 
   # clean preflight resource with a specified logging level
-  kubectl tvk-preflight cleanup --uid <preflight run uid> --log-level <log-level>
+  kubectl tvk-preflight cleanup --uid <preflight Run uid> --log-level <log-level>
 
   # Cleanup preflight resources with a particular kubeconfig file
   kubectl tvk-preflight cleanup --uid <preflight run uid> --namespace <namespace> --kubeconfig <kubeconfig-file-path>

--- a/cmd/preflight/cmd/constants.go
+++ b/cmd/preflight/cmd/constants.go
@@ -40,6 +40,9 @@ const (
 	PVCStorageRequestFlag  = "pvc-storage-request"
 	pvcStorageRequestUsage = "PVC storage request for volume snapshot preflight check"
 
+	NodeSelectorFlag  = "node-selector"
+	nodeSelectorUsage = "Node selector labels for pods to schedule on a specific nodes of cluster"
+
 	uidFlag  = "uid"
 	uidUsage = "UID of the preflight check whose resources must be cleaned"
 
@@ -70,5 +73,6 @@ var (
 	podLimits         string
 	podRequests       string
 	pvcStorageRequest string
+	nodeSelector      string
 	cleanupUID        string
 )

--- a/cmd/preflight/cmd/helper.go
+++ b/cmd/preflight/cmd/helper.go
@@ -82,10 +82,6 @@ func managePreflightInputs(cmd *cobra.Command) (err error) {
 			return fmt.Errorf("failed to read preflight input from file :: %s", err.Error())
 		}
 	}
-	err = updateNodeSelectorLabelsFromCLI(cmd)
-	if err != nil {
-		return err
-	}
 	return overridePreflightFileInputsFromCLI(cmd)
 }
 

--- a/cmd/preflight/cmd/run.go
+++ b/cmd/preflight/cmd/run.go
@@ -12,7 +12,7 @@ import (
 )
 
 // nolint:lll // ignore long line lint errors
-// runCmd represents the run command
+// runCmd represents the Run command
 var runCmd = &cobra.Command{
 	Use:   preflightRunCmdName,
 	Short: "Runs preflight checks on cluster",
@@ -31,7 +31,7 @@ var runCmd = &cobra.Command{
 
   # Cleanup the resources generated during preflight check if preflight check fails. Default is false.
   # If the preflight check is successful, then all resources are cleaned.
-  kubectl tvk-preflight run --storage-class <storage-class-name> --cleanup-on-failure 
+  kubectl tvk-preflight run --storage-class <storage-class-name> --Cleanup-on-failure 
 
   # run preflight with a particular kubeconfig file
   kubectl tvk-preflight run --storage-class <storage-class-name> --kubeconfig <kubeconfig-file-path>
@@ -93,4 +93,5 @@ func init() {
 	runCmd.Flags().StringVar(&podLimits, PodLimitFlag, "", podLimitUsage)
 	runCmd.Flags().StringVar(&podRequests, PodRequestFlag, "", podRequestUsage)
 	runCmd.Flags().StringVar(&pvcStorageRequest, PVCStorageRequestFlag, "", pvcStorageRequestUsage)
+	runCmd.Flags().StringVar(&nodeSelector, NodeSelectorFlag, "", nodeSelectorUsage)
 }

--- a/cmd/preflight/cmd/run.go
+++ b/cmd/preflight/cmd/run.go
@@ -31,7 +31,7 @@ var runCmd = &cobra.Command{
 
   # Cleanup the resources generated during preflight check if preflight check fails. Default is false.
   # If the preflight check is successful, then all resources are cleaned.
-  kubectl tvk-preflight run --storage-class <storage-class-name> --Cleanup-on-failure 
+  kubectl tvk-preflight run --storage-class <storage-class-name> --cleanup-on-failure 
 
   # run preflight with a particular kubeconfig file
   kubectl tvk-preflight run --storage-class <storage-class-name> --kubeconfig <kubeconfig-file-path>

--- a/docs/preflight/README.md
+++ b/docs/preflight/README.md
@@ -204,18 +204,6 @@ By `curl`
 curl https://github.com/trilioData/tvk-plugins/tree/main/docs/preflight/sample_input.yaml
 ```
 
-Run a preflight check with predefined values using a sample file. Download the file using below commands:
-
-By `wget`
-```shell script
-wget https://github.com/trilioData/tvk-plugins/tree/main/docs/preflight/sample_input.yaml
-```
-
-By `curl`
-```shell script
-curl https://github.com/trilioData/tvk-plugins/tree/main/docs/preflight/sample_input.yaml
-```
-
 #### Examples
 
 - With `--namespace`:

--- a/docs/preflight/README.md
+++ b/docs/preflight/README.md
@@ -172,7 +172,7 @@ run:
   imagePullSecret: <Name of the secret while pulling images from the local registry>
   cleanupOnFailure: <Boolean. If true cleans the preflight resources after a failed preflight run>
   pvcStorageRequest: <Storage request value of PVC for volume snapshot check>
-  podResourceRequirements:
+  resources:
     requests:
       memory: <pod memory request for snapshot check, e.g 64Mi>
       cpu: <pod cpu request for snapshot check, e.g 250m>
@@ -190,7 +190,19 @@ cleanup:
 - The **cleanupMode** field can have two values - *all* and *uid*. *all* mode will clean all the preflight resources present in the given namespace.
 *uid* mode will clean resources of preflight with the given *uid* in the given namespace.
 - User can override the values given in file using CLI flags.
-- The input fields should be present in the correct hierarchical order. An incorrect key or input field will result in an error and preflight checks will not performed.  
+- The input fields should be present in the correct hierarchical order. An incorrect key or input field will result in an error and preflight checks will not performed.
+
+Run a preflight check with predefined values using a sample file. Download the file using below commands:
+
+By `wget`
+```shell script
+wget https://github.com/trilioData/tvk-plugins/tree/main/docs/preflight/sample_input.yaml
+```
+
+By `curl`
+```shell script
+curl https://github.com/trilioData/tvk-plugins/tree/main/docs/preflight/sample_input.yaml
+```
 
 Run a preflight check with predefined values using a sample file. Download the file using below commands:
 
@@ -273,6 +285,7 @@ kubeconfig is pointing to in the given namespace.
 | --requests              | cpu=250m,memory=64Mi | Pod cpu and memory request for DNS and volume snapshot check. Memory and cpu values must be specified in a comma separated format. (Optional)
 | --limits              | cpu=500m,memory=128Mi | Pod cpu and memory limit for DNS and volume snapshot check. Memory and cpu values must be specified in a comma separated format. (Optional)
 | --pvc-storage-request   |     1Gi     | PVC storage request for performing volume snapshot check. (Optional)
+| --node-selector         |             | Node selector labels for scheduling pods on a set of particular nodes of a cluster (Optional)
 
 #### Examples
 
@@ -312,6 +325,107 @@ kubectl tvk-preflight run --storage-class <storageclass name> --requests cpu=200
 ```shell script
 kubectl tvk-preflight run --storage-class <storageclass name> --limits cpu=400m,memory=128Mi
 ```
+
+- With `--node-selector`: Multiple labels for node selection can be specified in a comma separated format. Where each label can be specified in a format `<label-key>=<label-value>`.
+
+```shell script
+kubectl tvk-preflight run --storage-class <storageclass name> --node-selector <label-key1>=<label-value1>,<label-key2>=<label-value2>
+```
+
+#### Pod Scheduling
+The pods of preflight run can be made to schedule on a particular set of nodes of cluster by specifying the labels for node selection, node affinity, pod affinity/anti-affinity and taints and toleration.
+
+**Note:** The labels except node-selector can only be specified through a config file of preflight run. Currently, it is not possible to specify pod and node affinity and tolerations through CLI flags.
+
+Please refer below examples for specifying labels onto the pods of preflight run.
+
+- Examples
+
+**Node selection**
+```yaml
+run:
+  ...
+  podSchedulingOptions:
+    nodeSelector:
+      node-sel-key: node-sel-value
+  ...
+```
+
+**Node-affinity**
+```yaml
+run:
+  ...
+  podSchedulingOptions:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+              - matchExpressions:
+                - key: pref-node-affinity
+                  operator: In
+                  values:
+                    - high
+                - key: pref-node-affinity
+                  operator: NotIn
+                  values:
+                    - low
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+                - key: pref-node-affinity
+                  operator: NotIn
+                  values:
+                    - medium
+  ...
+```
+
+**Pod-affinity/anti-affinity**
+```yaml
+run:
+  ...
+  podSchedulingOptions:
+    affinity:
+      podAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+              matchExpressions:
+                - key: pref-pod-affinity
+                  operator: In
+                  values:
+                    - medium
+                - key: pref-node-affinity
+                  operator: NotIn
+                  values:
+                    - high
+              topologyKey: preflight-topology
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: pref-pod-affinity
+                    operator: In
+                    values:
+                      - low
+              topologyKey: preflight-topology
+  ...
+```
+
+**Taints & Toleration**
+```yaml
+run:
+  ...
+  podSchedulingOptions:
+    tolerations:
+    - key: pref-node-taint
+      operator: Equal
+      value: pref-node-toleration
+      effect: NoSchedule
+  ...
+```
+
 
 ### 2. cleanup
 - **cleanup** subcommand cleans/deletes the resources created during failed preflight checks and not cleaned-up on failure.

--- a/tests/preflight/invalid_kc_file
+++ b/tests/preflight/invalid_kc_file
@@ -1,0 +1,1 @@
+invalid data

--- a/tests/preflight/preflight_suite_test.go
+++ b/tests/preflight/preflight_suite_test.go
@@ -45,6 +45,7 @@ const (
 	cpu600                   = "600m"
 	resourceCPUToken         = "cpu"
 	resourceMemoryToken      = "memory"
+	storageClassPlaceholder  = "STORAGE_CLASS"
 
 	dnsPodNamePrefix = "test-dns-pod-"
 	dnsContainerName = "test-dnsutils"
@@ -69,9 +70,9 @@ const (
 	mediumAffinity           = "medium"
 	lowAffinity              = "low"
 	debugLog                 = "debug"
-	preflightTaintKey        = "pref-node-taint"
-	preflightTaintValue      = "pref-node-toleration"
-	preflightTaintInvValue   = "pref-invalid-toleration"
+	//preflightTaintKey        = "pref-node-taint"
+	//preflightTaintValue      = "pref-node-toleration"
+	//preflightTaintInvValue   = "pref-invalid-toleration"
 )
 
 var (
@@ -199,11 +200,14 @@ var _ = BeforeSuite(func() {
 
 	snapshotGVK = getVolSnapshotGVK()
 	snapshotClassGVK = getVolSnapClassGVK()
+
+	assignPlaceholderValues()
 })
 
 var _ = AfterSuite(func() {
 	cmdOut, err = runCleanupForAllPreflightResources()
 	Expect(err).To(BeNil())
+	revertPlaceholderValues()
 	cleanDirForFiles(preflightLogFilePrefix)
 	cleanDirForFiles(cleanupLogFilePrefix)
 })
@@ -241,4 +245,28 @@ func getVolSnapClassGVK() schema.GroupVersionKind {
 		Version: prefVer,
 		Kind:    internal.VolumeSnapshotClassKind,
 	}
+}
+
+func assignPlaceholderValues() {
+	kv := map[string]string{
+		storageClassPlaceholder: defaultTestStorageClass,
+	}
+
+	Expect(testutils.UpdateYAMLs(kv, filepath.Join(testDataDirRelPath, podAffinityInputFile))).To(BeNil())
+	Expect(testutils.UpdateYAMLs(kv, filepath.Join(testDataDirRelPath, testFileInputName))).To(BeNil())
+	Expect(testutils.UpdateYAMLs(kv, filepath.Join(testDataDirRelPath, nodeAffinityInputFile))).To(BeNil())
+	Expect(testutils.UpdateYAMLs(kv, filepath.Join(testDataDirRelPath, invalidKeyYamlFileName))).To(BeNil())
+	Expect(testutils.UpdateYAMLs(kv, filepath.Join(testDataDirRelPath, taintsFileInputFile))).To(BeNil())
+}
+
+func revertPlaceholderValues() {
+	kv := map[string]string{
+		defaultTestStorageClass: storageClassPlaceholder,
+	}
+
+	Expect(testutils.UpdateYAMLs(kv, filepath.Join(testDataDirRelPath, testFileInputName))).To(BeNil())
+	Expect(testutils.UpdateYAMLs(kv, filepath.Join(testDataDirRelPath, podAffinityInputFile))).To(BeNil())
+	Expect(testutils.UpdateYAMLs(kv, filepath.Join(testDataDirRelPath, nodeAffinityInputFile))).To(BeNil())
+	Expect(testutils.UpdateYAMLs(kv, filepath.Join(testDataDirRelPath, invalidKeyYamlFileName))).To(BeNil())
+	Expect(testutils.UpdateYAMLs(kv, filepath.Join(testDataDirRelPath, taintsFileInputFile))).To(BeNil())
 }

--- a/tests/preflight/test-data/invalid_key_file.yaml
+++ b/tests/preflight/test-data/invalid_key_file.yaml
@@ -2,7 +2,7 @@ run:
   storageClass: csi-gce-pd
   cleanupOnFailure: true
   invalidKey: invalidValue
-  podResourceRequirements:
+  resources:
     requests:
       memory: 32Mi
       cpu: 250m

--- a/tests/preflight/test-data/invalid_key_file.yaml
+++ b/tests/preflight/test-data/invalid_key_file.yaml
@@ -1,5 +1,5 @@
 run:
-  storageClass: csi-gce-pd
+  storageClass: STORAGE_CLASS
   cleanupOnFailure: true
   invalidKey: invalidValue
   resources:

--- a/tests/preflight/test-data/node_affinity_preflight.yaml
+++ b/tests/preflight/test-data/node_affinity_preflight.yaml
@@ -1,5 +1,5 @@
 run:
-  storageClass: csi-gce-pd
+  storageClass: STORAGE_CLASS
   cleanupOnFailure: true
   logLevel: debug
   podSchedulingOptions:

--- a/tests/preflight/test-data/node_affinity_preflight.yaml
+++ b/tests/preflight/test-data/node_affinity_preflight.yaml
@@ -1,0 +1,26 @@
+run:
+  storageClass: csi-gce-pd
+  cleanupOnFailure: true
+  logLevel: debug
+  podSchedulingOptions:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: pref-node-affinity
+                  operator: In
+                  values:
+                    - high
+                - key: pref-node-affinity
+                  operator: NotIn
+                  values:
+                    - low
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+                - key: pref-node-affinity
+                  operator: NotIn
+                  values:
+                    - medium

--- a/tests/preflight/test-data/pod_affinity_preflight.yaml
+++ b/tests/preflight/test-data/pod_affinity_preflight.yaml
@@ -1,5 +1,5 @@
 run:
-  storageClass: csi-gce-pd
+  storageClass: STORAGE_CLASS
   cleanupOnFailure: true
   logLevel: debug
   podSchedulingOptions:

--- a/tests/preflight/test-data/pod_affinity_preflight.yaml
+++ b/tests/preflight/test-data/pod_affinity_preflight.yaml
@@ -1,0 +1,30 @@
+run:
+  storageClass: csi-gce-pd
+  cleanupOnFailure: true
+  logLevel: debug
+  podSchedulingOptions:
+    affinity:
+      podAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: pref-pod-affinity
+                  operator: In
+                  values:
+                    - medium
+                - key: pref-node-affinity
+                  operator: NotIn
+                  values:
+                    - high
+            topologyKey: preflight-topology
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: pref-pod-affinity
+                    operator: In
+                    values:
+                      - low
+              topologyKey: preflight-topology

--- a/tests/preflight/test-data/preflight_file_input.yaml
+++ b/tests/preflight/test-data/preflight_file_input.yaml
@@ -13,4 +13,3 @@ run:
 
 cleanup:
   logLevel: info
-  cleanupMode: all

--- a/tests/preflight/test-data/preflight_file_input.yaml
+++ b/tests/preflight/test-data/preflight_file_input.yaml
@@ -1,5 +1,5 @@
 run:
-  storageClass: csi-gce-pd
+  storageClass: STORAGE_CLASS
   cleanupOnFailure: true
   snapshotClass: default-snapshot-class
   pvcStorageRequest: 1Gi

--- a/tests/preflight/test-data/taints_tolerations_preflight.yaml
+++ b/tests/preflight/test-data/taints_tolerations_preflight.yaml
@@ -1,6 +1,5 @@
 run:
-  namespace: tvk-prasad
-  storageClass: csi-gce-pd
+  storageClass: STORAGE_CLASS
   cleanupOnFailure: false
   podSchedulingOptions:
     nodeSelector:

--- a/tests/preflight/test-data/taints_tolerations_preflight.yaml
+++ b/tests/preflight/test-data/taints_tolerations_preflight.yaml
@@ -1,0 +1,12 @@
+run:
+  namespace: tvk-prasad
+  storageClass: csi-gce-pd
+  cleanupOnFailure: false
+  podSchedulingOptions:
+    nodeSelector:
+      preflight-topology: preflight-node
+    tolerations:
+      - key: pref-node-taint
+        operator: Equal
+        value: pref-node-toleration
+        effect: NoSchedule

--- a/tests/preflight/test_helper.go
+++ b/tests/preflight/test_helper.go
@@ -513,25 +513,22 @@ func deletePreflightServiceAccount() {
 }
 
 func createAffineBusyboxPod(podName, affinity, namespace string) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				preflightPodAffinityKey: affinity,
+	var uid string
+	uid, err = preflight.CreateResourceNameSuffix()
+	Expect(err).To(BeNil())
+	pod := getPodTemplate(podName, uid)
+	podLabels := pod.GetLabels()
+	podLabels[preflightPodAffinityKey] = affinity
+	pod.Spec = corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:    preflight.BusyboxContainerName,
+				Image:   preflight.BusyboxImageName,
+				Command: preflight.CommandBinSh,
 			},
 		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:    preflight.BusyboxContainerName,
-					Image:   preflight.BusyboxImageName,
-					Command: preflight.CommandBinSh,
-				},
-			},
-			NodeSelector: map[string]string{
-				preflightNodeLabelKey: preflightNodeLabelValue,
-			},
+		NodeSelector: map[string]string{
+			preflightNodeLabelKey: preflightNodeLabelValue,
 		},
 	}
 

--- a/tests/test_utils/utils.go
+++ b/tests/test_utils/utils.go
@@ -1,8 +1,12 @@
 package testutils
 
 import (
+	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/trilioData/tvk-plugins/internal"
 )
 
@@ -12,4 +16,58 @@ func GetInstallNamespace() string {
 		panic("Install Namespace not found in environment")
 	}
 	return namespace
+}
+
+// UpdateYAMLs Update old YAML values with new values
+// fileOrDirPath can be a single file path or a directory
+// kv is map of old value to new value
+func UpdateYAMLs(kv map[string]string, fileOrDirPath string) error {
+	var files []string
+	info, err := os.Stat(fileOrDirPath)
+
+	if os.IsNotExist(err) {
+		return err
+	}
+
+	var walkFn = func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() {
+			files = append(files, path)
+		}
+
+		return nil
+	}
+
+	if info.IsDir() {
+		if err := filepath.Walk(fileOrDirPath, walkFn); err != nil {
+			return err
+		}
+	} else {
+		files = append(files, fileOrDirPath)
+	}
+
+	for _, yamlPath := range files {
+		read, readErr := ioutil.ReadFile(yamlPath)
+		if readErr != nil {
+			return readErr
+		}
+
+		updatedFile := string(read)
+
+		for placeholder, value := range kv {
+			if strings.Contains(updatedFile, placeholder) {
+				updatedFile = strings.ReplaceAll(updatedFile, placeholder, value)
+				log.Infof("Updated the old value: [%s] with new value: [%s] in file [%s]",
+					placeholder, value, yamlPath)
+			}
+		}
+
+		if writeErr := ioutil.WriteFile(yamlPath, []byte(updatedFile), 0); writeErr != nil {
+			return writeErr
+		}
+	}
+	return nil
 }

--- a/tools/preflight/cleanup.go
+++ b/tools/preflight/cleanup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,8 +19,7 @@ type CleanupOptions struct {
 type Cleanup struct {
 	CleanupOptions
 	CommonOptions
-	CleanupMode string `json:"cleanupMode"`
-	UID         string `json:"uid"`
+	UID string `json:"uid"`
 }
 
 func (co *Cleanup) logCleanupOptions() {
@@ -106,15 +106,9 @@ func getCleanupResourceGVKList() ([]schema.GroupVersionKind, error) {
 		})
 	}
 
-	cleanupResourceList = append(cleanupResourceList, schema.GroupVersionKind{
-		Group:   "",
-		Version: "v1",
-		Kind:    internal.PersistentVolumeClaimKind,
-	}, schema.GroupVersionKind{
-		Group:   "",
-		Version: "v1",
-		Kind:    internal.PodKind,
-	})
+	cleanupResourceList = append(cleanupResourceList,
+		corev1.SchemeGroupVersion.WithKind(internal.PersistentVolumeClaimKind),
+		corev1.SchemeGroupVersion.WithKind(internal.PodKind))
 
 	return cleanupResourceList, nil
 }

--- a/tools/preflight/cleanup.go
+++ b/tools/preflight/cleanup.go
@@ -18,6 +18,8 @@ type CleanupOptions struct {
 type Cleanup struct {
 	CleanupOptions
 	CommonOptions
+	CleanupMode string `json:"cleanupMode"`
+	UID         string `json:"uid"`
 }
 
 func (co *Cleanup) logCleanupOptions() {
@@ -52,6 +54,7 @@ func (co *Cleanup) CleanupPreflightResources(ctx context.Context) error {
 	if co.UID != "" {
 		resLabels[LabelPreflightRunKey] = co.UID
 	}
+
 	for _, gvk := range gvkList {
 		var resList = unstructured.UnstructuredList{}
 		resList.SetGroupVersionKind(gvk)
@@ -90,15 +93,6 @@ func (co *Cleanup) cleanResource(ctx context.Context, resource *unstructured.Uns
 
 func getCleanupResourceGVKList() ([]schema.GroupVersionKind, error) {
 	cleanupResourceList := make([]schema.GroupVersionKind, 0)
-	cleanupResourceList = append(cleanupResourceList, schema.GroupVersionKind{
-		Group:   "",
-		Version: "v1",
-		Kind:    internal.PodKind,
-	}, schema.GroupVersionKind{
-		Group:   "",
-		Version: "v1",
-		Kind:    internal.PersistentVolumeClaimKind,
-	})
 
 	snapVerList, err := getVersionsOfGroup(StorageSnapshotGroup)
 	if err != nil {
@@ -111,6 +105,16 @@ func getCleanupResourceGVKList() ([]schema.GroupVersionKind, error) {
 			Kind:    internal.VolumeSnapshotKind,
 		})
 	}
+
+	cleanupResourceList = append(cleanupResourceList, schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    internal.PersistentVolumeClaimKind,
+	}, schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    internal.PodKind,
+	})
 
 	return cleanupResourceList, nil
 }


### PR DESCRIPTION
Added support for scheduling of preflight pods.

One CLI flag added - `node-selector` - Allows user to input multiple labels for node selection to schedule pods on a particular set of nodes.

Pod scheduling supports node selection, pod affinity/anti-affinity, node affinity and taints and tolerations.
Except node-selector flag other pod scheduling options currently do not have CLI flag support. Input for these pod scheduling options must be given through the config file.
This is because there are a lot of options to specify in affinity and tolerations. Hence, input only through config file is supported.