### PR TITLE
TK-5633: Updates minimum supported k8s version in preflight check to 1.19

### DIFF
--- a/docs/preflight/README.md
+++ b/docs/preflight/README.md
@@ -56,7 +56,7 @@ The following checks are included in preflight:
     2. Aborts successfully for Openshift cluster
     3. This check is skipped if `--in-cluster` flag is enabled.
 
-4. `check-kubernetes-version` - Ensures minimum Kubernetes version >= 1.18.x
+4. `check-kubernetes-version` - Ensures minimum Kubernetes version >= 1.19.x
 
 5. `check-kubernetes-rbac` - Ensures RBAC is enabled in cluster
 

--- a/tools/preflight/helper.go
+++ b/tools/preflight/helper.go
@@ -38,7 +38,7 @@ const (
 	windowsCrossSymbol = "[X]"
 
 	minHelmVersion = "3.0.0"
-	minK8sVersion  = "1.18.0"
+	minK8sVersion  = "1.19.0"
 
 	rbacAPIGroup   = "rbac.authorization.k8s.io"
 	rbacAPIVersion = "v1"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR, and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->
Updates minimum supported k8s version in preflight check to 1.19 as TVK's min supported k8s version is moved to 1.19
<!-- What does this do, and why do we need it? -->
