### PR TITLE
:bug: TK-5684 Error occurs while cleaning resources in preflight cleanup

### DIFF
--- a/tools/preflight/helper.go
+++ b/tools/preflight/helper.go
@@ -602,7 +602,7 @@ func deleteK8sResource(ctx context.Context, obj client.Object, cl client.Client)
 
 	err = cl.Delete(ctx, obj, client.DeleteOption(client.GracePeriodSeconds(deletionGracePeriod)))
 	if err != nil {
-		return fmt.Errorf("problem occurred deleting %s - %s :: %s", obj.GetName(), obj.GetNamespace(), err.Error())
+		return err
 	}
 
 	gvk := obj.GetObjectKind().GroupVersionKind()


### PR DESCRIPTION
Internal func `deleteK8sResource` returns raw error.
Error handling and formatting is done by its caller i.e `cleanResource`.