### PR TITLE
:bug: TK-5685 Parsing helm version on from shell output

### DIFF
--- a/tools/preflight/helper_test.go
+++ b/tools/preflight/helper_test.go
@@ -61,6 +61,67 @@ var _ = Describe("Preflight Helper Funcs Unit Tests", func() {
 		})
 	})
 
+	Context("when extracting version of type vX.Y.Z from string of sentences", func() {
+
+		Context("When valid version is present in string", func() {
+
+			It("Should extract version when version is mentioned at the end of the string", func() {
+				verStr := fmt.Sprintf("%s %s v%s", testSentence, testSentence, minHelmVersion)
+				version, err := extractVersionFromString(verStr)
+				Expect(err).To(BeNil())
+				Expect(version).To(Equal(minHelmVersion))
+			})
+
+			It("Should extract version when version is mentioned at the start of the string", func() {
+				verStr := fmt.Sprintf("v%s %s %s", minHelmVersion, testSentence, testSentence)
+				version, err := extractVersionFromString(verStr)
+				Expect(err).To(BeNil())
+				Expect(version).To(Equal(minHelmVersion))
+			})
+
+			It("Should extract version when version is mentioned in the middle of the string", func() {
+				verStr := fmt.Sprintf("%s v%s %s", testSentence, minHelmVersion, testSentence)
+				version, err := extractVersionFromString(verStr)
+				Expect(err).To(BeNil())
+				Expect(version).To(Equal(minHelmVersion))
+			})
+
+			It("Should extract the last version of string when multiple valid versions are present in the string", func() {
+				verStr := fmt.Sprintf("%s v%s %s v%s", testSentence, minHelmVersion, testSentence, minK8sVersion)
+				version, err := extractVersionFromString(verStr)
+				Expect(err).To(BeNil())
+				Expect(version).To(Equal(minK8sVersion))
+			})
+		})
+
+		Context("When invalid version is present in the string", func() {
+
+			It("Should return error when major numeral of version is not a digit", func() {
+				_, err := extractVersionFromString("va1.2.3")
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(ContainSubstring("no version of type vX.Y.Z found in the string"))
+			})
+
+			It("Should return error when minor numeral of version is not a digit", func() {
+				_, err := extractVersionFromString("v1.a2.3")
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(ContainSubstring("no version of type vX.Y.Z found in the string"))
+			})
+
+			It("Should return error when patch numeral of version is not a digit", func() {
+				_, err := extractVersionFromString("v1.2.a3")
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(ContainSubstring("no version of type vX.Y.Z found in the string"))
+			})
+
+			It("Should return error when there is no version specified in the string", func() {
+				_, err := extractVersionFromString(testSentence)
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(ContainSubstring("no version of type vX.Y.Z found in the string"))
+			})
+		})
+	})
+
 	Context("Fetch server preferred version for a API group on cluster", func() {
 
 		It("Should return preferred version of valid group using a go-client", func() {

--- a/tools/preflight/preflight.go
+++ b/tools/preflight/preflight.go
@@ -109,6 +109,7 @@ func (o *Run) PerformPreflightChecks(ctx context.Context) error {
 		}
 	}
 
+	// check cluster default ns access
 	o.Logger.Infoln("Checking access to the default namespace of cluster")
 	err = o.checkClusterAccess(ctx, internal.DefaultNs, kubeClient.ClientSet)
 	if err != nil {
@@ -118,6 +119,7 @@ func (o *Run) PerformPreflightChecks(ctx context.Context) error {
 		o.Logger.Infof("%s Preflight check for kubectl access is successful\n", check)
 	}
 
+	// Helm check
 	if o.InCluster {
 		o.Logger.Infoln("In cluster flag enabled. Skipping check for helm...")
 	} else {
@@ -131,6 +133,7 @@ func (o *Run) PerformPreflightChecks(ctx context.Context) error {
 		}
 	}
 
+	// kubernetes server version check
 	o.Logger.Infof("Checking for required kubernetes server version (>=%s)\n", minK8sVersion)
 	err = o.checkKubernetesVersion(minK8sVersion, kubeClient.ClientSet)
 	if err != nil {
@@ -140,6 +143,7 @@ func (o *Run) PerformPreflightChecks(ctx context.Context) error {
 		o.Logger.Infof("%s Preflight check for kubernetes version is successful\n", check)
 	}
 
+	// rbac check
 	o.Logger.Infoln("Checking Kubernetes RBAC")
 	err = o.checkKubernetesRBAC(RBACAPIGroup, RBACAPIVersion, kubeClient.DiscClient)
 	if err != nil {
@@ -211,8 +215,8 @@ func (o *Run) PerformPreflightChecks(ctx context.Context) error {
 	}
 
 	//  Check DNS resolution
-	o.Logger.Infoln("Checking if DNS resolution is working in k8s cluster")
 	err = o.checkDNSResolution(ctx, execDNSResolutionCmd, resNameSuffix, kubeClient)
+	o.Logger.Infoln("Checking if DNS resolution is working in k8s cluster")
 	if err != nil {
 		o.Logger.Errorf("%s Preflight check for DNS resolution failed :: %s\n", cross, err.Error())
 		preflightStatus = false

--- a/tools/preflight/suite_test.go
+++ b/tools/preflight/suite_test.go
@@ -48,6 +48,7 @@ const (
 	testSnapshotClass = "ut-snapshot-class"
 	testDriver        = "test.snapshot.driver.io"
 	testMinK8sVersion = "1.10.0"
+	testSentence      = "This is a test-sentence with special char $%^&*() which can be inserted anywhere in test data"
 
 	installNs = internal.DefaultNs
 )


### PR DESCRIPTION
Parsing helm version on from shell output can give error if output contains strings/info along with version.
Now, regex matching is used to extract version from input string.