### PR TITLE
:bug: TK-5747 preflight-check on MKE fails

### DIFF
--- a/tools/preflight/helper.go
+++ b/tools/preflight/helper.go
@@ -509,14 +509,17 @@ func getPodTemplate(name, uid string, op *Run) *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: getObjectMetaTemplate(name, op.Namespace, uid),
 		Spec: corev1.PodSpec{
-			ImagePullSecrets: []corev1.LocalObjectReference{
-				{Name: op.ImagePullSecret},
-			},
 			ServiceAccountName: op.ServiceAccountName,
 			NodeSelector:       op.PodSchedOps.NodeSelector,
 			Affinity:           op.PodSchedOps.Affinity,
 			Tolerations:        op.PodSchedOps.Tolerations,
 		},
+	}
+
+	if op.ImagePullSecret != "" {
+		pod.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+			{Name: op.ImagePullSecret},
+		}
 	}
 
 	return pod


### PR DESCRIPTION
Whener user hasn't provided any image-pull-secret, an empty image-pull-secret object would be added to pod's spec.
This case is now handled using an `if` check.

If user has provided a non-zero length image-pull-secret then pull-secret is applied to pod else, it is not applied.