### PR TITLE
:sparkles: TK-5683 Add env tests for DNS resolution and volume snapshot

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,9 +1,13 @@
 package internal
 
 import (
+	cryptorand "crypto/rand"
+	"math/big"
+	"math/rand"
+	"time"
+
 	log "github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
@@ -39,4 +43,20 @@ func CheckIsOpenshift(disClient *discovery.DiscoveryClient, groupVersion string)
 		}
 	}
 	return true
+}
+
+func GenerateRandomString(n int, isOnlyAlphabetic bool) string {
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	numbers := "1234567890"
+	rand.Seed(time.Now().UnixNano())
+	letterRunes := []rune(letters)
+	if !isOnlyAlphabetic {
+		letterRunes = []rune(letters + numbers)
+	}
+	b := make([]rune, n)
+	for i := range b {
+		randNum, _ := cryptorand.Int(cryptorand.Reader, big.NewInt(int64(len(letterRunes))))
+		b[i] = letterRunes[randNum.Int64()]
+	}
+	return string(b)
 }

--- a/tools/preflight/helper.go
+++ b/tools/preflight/helper.go
@@ -419,10 +419,11 @@ func createVolumeSnapshotPodSpec(pvcName string, op *Run, nameSuffix string) *co
 // createVolumeSnapsotSpec creates pvc for volume snapshot
 func createVolumeSnapsotSpec(name, snapshotClass, namespace, snapVer, pvcName, uid string) *unstructured.Unstructured {
 	volSnap := &unstructured.Unstructured{}
+
 	volSnap.Object = map[string]interface{}{
 		"spec": map[string]interface{}{
 			"volumeSnapshotClassName": snapshotClass,
-			"source": map[string]string{
+			"source": map[string]interface{}{
 				"persistentVolumeClaimName": pvcName,
 			},
 		},

--- a/tools/preflight/helper.go
+++ b/tools/preflight/helper.go
@@ -556,7 +556,8 @@ func waitUntilPodCondition(ctx context.Context, wop *wait.PodWaitOptions) error 
 }
 
 // waitUntilVolSnapReadyToUse waits until volume snapshot becomes ready or timeouts
-func waitUntilVolSnapReadyToUse(volSnap *unstructured.Unstructured, snapshotVer string, retryBackoff k8swait.Backoff) error {
+func waitUntilVolSnapReadyToUse(volSnap *unstructured.Unstructured, snapshotVer string,
+	retryBackoff k8swait.Backoff, runtimeClient client.Client) error {
 	retErr := k8swait.ExponentialBackoff(retryBackoff, func() (done bool, err error) {
 		volSnapSrc := &unstructured.Unstructured{}
 		volSnapSrc.SetGroupVersionKind(schema.GroupVersionKind{
@@ -564,7 +565,7 @@ func waitUntilVolSnapReadyToUse(volSnap *unstructured.Unstructured, snapshotVer 
 			Version: snapshotVer,
 			Kind:    internal.VolumeSnapshotKind,
 		})
-		err = kubeClient.RuntimeClient.Get(context.Background(), client.ObjectKey{
+		err = runtimeClient.Get(context.Background(), client.ObjectKey{
 			Namespace: volSnap.GetNamespace(),
 			Name:      volSnap.GetName(),
 		}, volSnapSrc)

--- a/tools/preflight/preflight.go
+++ b/tools/preflight/preflight.go
@@ -575,7 +575,7 @@ func (o *Run) checkAndCreateVolumeSnapshotCRDs(ctx context.Context, serverVersio
 func (o *Run) validateDNSResolution(ctx context.Context, execCommand []string, podNameSuffix string, clients ServerClients) error {
 	pod, err := o.createDNSPodOnCluster(ctx, podNameSuffix, clients.ClientSet)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	op := exec.Options{

--- a/tools/preflight/preflight.go
+++ b/tools/preflight/preflight.go
@@ -573,32 +573,10 @@ func (o *Run) checkAndCreateVolumeSnapshotCRDs(ctx context.Context, serverVersio
 
 //  validateDNSResolution checks whether DNS resolution is working on k8s cluster
 func (o *Run) validateDNSResolution(ctx context.Context, execCommand []string, podNameSuffix string, clients ServerClients) error {
-	pod := createDNSPodSpec(o, podNameSuffix)
-	_, err := clients.ClientSet.CoreV1().Pods(o.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+	pod, err := o.createDNSPodOnCluster(ctx, podNameSuffix, clients.ClientSet)
 	if err != nil {
-		return err
+		return nil
 	}
-	o.Logger.Infof("Pod %s created in cluster\n", pod.GetName())
-
-	waitOptions := &wait.PodWaitOptions{
-		Name:               pod.GetName(),
-		Namespace:          o.Namespace,
-		RetryBackoffParams: getDefaultRetryBackoffParams(),
-		PodCondition:       corev1.PodReady,
-		ClientSet:          clients.ClientSet,
-	}
-	o.Logger.Infoln("Waiting for dns pod to become ready")
-	err = waitUntilPodCondition(ctx, waitOptions)
-	if err != nil {
-		o.Logger.Errorf("DNS pod - %s hasn't reached into ready state", pod.GetName())
-		return err
-	}
-
-	pod, err = clients.ClientSet.CoreV1().Pods(o.Namespace).Get(ctx, pod.GetName(), metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	logPodScheduleStmt(pod, o.Logger)
 
 	op := exec.Options{
 		Namespace:     o.Namespace,
@@ -625,20 +603,64 @@ func (o *Run) validateDNSResolution(ctx context.Context, execCommand []string, p
 	return nil
 }
 
+func (o *Run) createDNSPodOnCluster(ctx context.Context, podNameSuffix string, clientSet *kubernetes.Clientset) (*corev1.Pod, error) {
+	pod := createDNSPodSpec(o, podNameSuffix)
+	_, err := clientSet.CoreV1().Pods(o.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	o.Logger.Infof("Pod %s created in cluster\n", pod.GetName())
+
+	waitOptions := &wait.PodWaitOptions{
+		Name:               pod.GetName(),
+		Namespace:          o.Namespace,
+		RetryBackoffParams: getDefaultRetryBackoffParams(),
+		PodCondition:       corev1.PodReady,
+		ClientSet:          clientSet,
+	}
+	o.Logger.Infoln("Waiting for dns pod to become ready")
+	err = waitUntilPodCondition(ctx, waitOptions)
+	if err != nil {
+		o.Logger.Errorf("DNS pod - %s hasn't reached into ready state", pod.GetName())
+		return nil, err
+	}
+
+	pod, err = clientSet.CoreV1().Pods(o.Namespace).Get(ctx, pod.GetName(), metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	logPodScheduleStmt(pod, o.Logger)
+
+	return pod, nil
+}
+
 // validateVolumeSnapshot checks if volume snapshot and restore is enabled in the cluster
 func (o *Run) validateVolumeSnapshot(ctx context.Context, nameSuffix string, clients ServerClients) error {
 	var (
-		execOp exec.Options
-		err    error
+		execOp          exec.Options
+		err             error
+		pvc             *corev1.PersistentVolumeClaim
+		srcPod          *corev1.Pod
+		prefSnapshotVer string
 	)
 
+	prefSnapshotVer, err = GetServerPreferredVersionForGroup(StorageSnapshotGroup, clients.ClientSet)
+	if err != nil {
+		return err
+	}
+
 	// create source pod, pvc and volume snapshot
-	pvc, srcPod, err := o.createSourcePodAndPVC(ctx, nameSuffix, clients.ClientSet)
+	pvc, err = o.createSourcePVC(ctx, nameSuffix, clients.ClientSet)
+	if err != nil {
+		return err
+	}
+	o.Logger.Infof("Created source pvc - %s", pvc.GetName())
+	srcPod, err = o.createSourcePodFromPVC(ctx, nameSuffix, pvc.GetName(), clients.ClientSet)
 	if err != nil {
 		return err
 	}
 	volSnap, err := o.createSnapshotFromPVC(ctx, VolumeSnapSrcNamePrefix+nameSuffix,
-		storageVolSnapClass, pvc.GetName(), nameSuffix, clients)
+		storageVolSnapClass, prefSnapshotVer, pvc.GetName(), nameSuffix, clients)
 	if err != nil {
 		return err
 	}
@@ -680,7 +702,7 @@ func (o *Run) validateVolumeSnapshot(ctx context.Context, nameSuffix string, cli
 
 	// create unmounted pod, pvc and  snapshot from source pvc
 	unmountedVolSnapSrc, err := o.createSnapshotFromPVC(ctx, UnmountedVolumeSnapSrcNamePrefix+nameSuffix,
-		storageVolSnapClass, pvc.GetName(), nameSuffix, clients)
+		storageVolSnapClass, prefSnapshotVer, pvc.GetName(), nameSuffix, clients)
 	if err != nil {
 		return err
 	}
@@ -701,21 +723,26 @@ func (o *Run) validateVolumeSnapshot(ctx context.Context, nameSuffix string, cli
 	return nil
 }
 
-// createSourcePodAndPVC creates source pod and pvc for volume snapshot check
-func (o *Run) createSourcePodAndPVC(ctx context.Context, nameSuffix string,
-	k8sClient *kubernetes.Clientset) (*corev1.PersistentVolumeClaim, *corev1.Pod, error) {
-	var err error
-	pvc := createVolumeSnapshotPVCSpec(o, SourcePvcNamePrefix+nameSuffix, nameSuffix)
+func (o *Run) createSourcePVC(ctx context.Context, nameSuffix string,
+	k8sClient *kubernetes.Clientset) (pvc *corev1.PersistentVolumeClaim, err error) {
+	pvc = createVolumeSnapshotPVCSpec(o, SourcePvcNamePrefix+nameSuffix, nameSuffix)
 	pvc, err = k8sClient.CoreV1().PersistentVolumeClaims(o.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	o.Logger.Infof("Created source pvc - %s", pvc.GetName())
-	srcPod := createVolumeSnapshotPodSpec(pvc.GetName(), o, nameSuffix)
+
+	return pvc, nil
+}
+
+// createSourcePodFromPVC creates source pod and pvc for volume snapshot check
+func (o *Run) createSourcePodFromPVC(ctx context.Context, nameSuffix, pvcName string,
+	k8sClient *kubernetes.Clientset) (srcPod *corev1.Pod, err error) {
+
+	srcPod = createVolumeSnapshotPodSpec(pvcName, o, nameSuffix)
 	srcPod, err = k8sClient.CoreV1().Pods(o.Namespace).Create(ctx, srcPod, metav1.CreateOptions{})
 	if err != nil {
 		o.Logger.Errorln(err.Error())
-		return pvc, nil, err
+		return nil, err
 	}
 	o.Logger.Infof("Created source pod - %s", srcPod.GetName())
 
@@ -730,34 +757,29 @@ func (o *Run) createSourcePodAndPVC(ctx context.Context, nameSuffix string,
 	o.Logger.Infof("Waiting for source pod - %s to become ready\n", srcPod.GetName())
 	err = waitUntilPodCondition(ctx, waitOptions)
 	if err != nil {
-		return pvc, srcPod, fmt.Errorf("pod %s hasn't reached into ready state", srcPod.GetName())
+		return srcPod, fmt.Errorf("pod %s hasn't reached into ready state", srcPod.GetName())
 	}
 	o.Logger.Infof("Source pod - %s has reached into ready state\n", srcPod.GetName())
 
 	srcPod, err = k8sClient.CoreV1().Pods(o.Namespace).Get(ctx, srcPod.GetName(), metav1.GetOptions{})
 	if err != nil {
-		return pvc, srcPod, err
+		return srcPod, err
 	}
 	logPodScheduleStmt(srcPod, o.Logger)
 
-	return pvc, srcPod, err
+	return srcPod, err
 }
 
-func (o *Run) createSnapshotFromPVC(ctx context.Context, volSnapName, volSnapClass,
+func (o *Run) createSnapshotFromPVC(ctx context.Context, volSnapName, volSnapClass, snapshotVer,
 	pvcName, uid string, clients ServerClients) (*unstructured.Unstructured, error) {
-	snapshotVer, err := GetServerPreferredVersionForGroup(StorageSnapshotGroup, clients.ClientSet)
-	if err != nil {
-		o.Logger.Errorln(err.Error())
-		return nil, err
-	}
 	volSnap := createVolumeSnapsotSpec(volSnapName, volSnapClass, o.Namespace, snapshotVer, pvcName, uid)
-	if err = clients.RuntimeClient.Create(ctx, volSnap); err != nil {
+	if err := clients.RuntimeClient.Create(ctx, volSnap); err != nil {
 		return nil, fmt.Errorf("%s error creating volume snapshot from pvc :: %s", cross, err.Error())
 	}
 	o.Logger.Infof("Created volume snapshot - %s from pvc", volSnap.GetName())
 
 	o.Logger.Infof("Waiting for volume snapshot - %s created from pvc to become 'readyToUse:true'", volSnap.GetName())
-	err = waitUntilVolSnapReadyToUse(volSnap, snapshotVer, getDefaultRetryBackoffParams())
+	err := waitUntilVolSnapReadyToUse(volSnap, snapshotVer, getDefaultRetryBackoffParams(), clients.RuntimeClient)
 	if err != nil {
 		if err == k8swait.ErrWaitTimeout {
 			return nil, fmt.Errorf("volume snapshot - %s not readyToUse (waited 600 sec) :: %s",

--- a/tools/preflight/preflight_test.go
+++ b/tools/preflight/preflight_test.go
@@ -5,12 +5,15 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -234,6 +237,415 @@ func preflightFuncsTestcases() {
 		})
 	})
 
+	Describe("Preflight volume snapshot resources test scenarios", func() {
+
+		Context("When creating source pod from pvc", func() {
+			var (
+				nameSuffix string
+				err        error
+				pvc        = &corev1.PersistentVolumeClaim{}
+				pod        = &corev1.Pod{}
+				pvcKey     types.NamespacedName
+				podKey     types.NamespacedName
+				resultChan = make(chan error, 1)
+				once       sync.Once
+			)
+
+			BeforeEach(func() {
+				once.Do(func() {
+					nameSuffix, err = CreateResourceNameSuffix()
+					pvcKey = types.NamespacedName{
+						Name:      testPVC + "-" + internal.GenerateRandomString(6, false),
+						Namespace: installNs,
+					}
+					podKey = types.NamespacedName{
+						Name:      SourcePodNamePrefix + nameSuffix,
+						Namespace: installNs,
+					}
+
+					Expect(err).To(BeNil())
+					err = createTestPVC(pvcKey)
+					Expect(err).To(BeNil())
+					Eventually(func() error {
+						return testClient.RuntimeClient.Get(ctx, pvcKey, pvc)
+					}, timeout, interval).Should(BeNil())
+
+					// Bind the PVC
+					pvc.Status.Phase = corev1.ClaimBound
+					Expect(testClient.RuntimeClient.Status().Update(ctx, pvc)).To(BeNil())
+					Eventually(func() bool {
+						Expect(testClient.RuntimeClient.Get(ctx, pvcKey, pvc)).To(BeNil())
+						return pvc.Status.Phase == corev1.ClaimBound
+					})
+
+					// create pod from pvc
+					go func(pvcName string) {
+						var testErr error
+						pod, testErr = runOps.createSourcePodFromPVC(ctx, nameSuffix, pvcName, testClient.ClientSet)
+						resultChan <- testErr
+					}(pvc.GetName())
+				})
+			})
+
+			It("Should create source pod with appropriate spec fields", func() {
+				unstructPod := &unstructured.Unstructured{}
+				unstructPod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind(internal.PodKind))
+				Eventually(func() error {
+					return testClient.RuntimeClient.Get(ctx, podKey, unstructPod)
+				}, timeout, interval).Should(BeNil())
+
+				specObj, found, err := unstructured.NestedFieldNoCopy(unstructPod.Object, "spec", "volumes")
+				Expect(found).To(BeTrue())
+				Expect(err).To(BeNil())
+
+				specObj = specObj.([]interface{})[0]
+				val, ok := specObj.(map[string]interface{})["name"]
+				Expect(ok).To(BeTrue())
+				Expect(val).To(Equal(VolMountName))
+
+				pvcMap, ok := specObj.(map[string]interface{})["persistentVolumeClaim"]
+				Expect(ok).To(BeTrue())
+
+				val, ok = pvcMap.(map[string]interface{})["claimName"]
+				Expect(ok).To(BeTrue())
+				Expect(val).To(Equal(pvcKey.Name))
+
+				verifyTVKResourceLabels(unstructPod, nameSuffix)
+			})
+
+			It("Should create source pod from pvc in bound state", func() {
+				// Get the source pod from cache
+				Eventually(func() error {
+					return testClient.RuntimeClient.Get(ctx, podKey, pod)
+				}, timeout, interval).Should(BeNil())
+
+				// Update the status of pod to ready
+				Expect(testClient.RuntimeClient.Get(ctx, podKey, pod)).To(BeNil())
+				pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+					Type:               corev1.PodReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: time.Now()},
+				})
+				Expect(testClient.RuntimeClient.Status().Update(ctx, pod)).To(BeNil())
+
+				Expect(<-resultChan).To(BeNil())
+			})
+		})
+
+		Context("When creating volume snapshot from pvc", Ordered, func() {
+
+			var (
+				volSnapKey types.NamespacedName
+				volSnap    = &unstructured.Unstructured{}
+				vsCRDsMap  = map[string]bool{vsClassCRD: true, vsContentCRD: true, vsCRD: true}
+				resultChan = make(chan error, 1)
+			)
+
+			BeforeAll(func() {
+				// Install the volume snapshot CRDs
+				installVolumeSnapshotCRD(v1K8sVersion, vsCRDsMap)
+				checkVolumeSnapshotCRDExists()
+
+				// create volume-snapshot on cluster
+				volSnapKey = types.NamespacedName{
+					Name:      testVolumeSnapshot,
+					Namespace: runOps.Namespace,
+				}
+
+				volSnap.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   StorageSnapshotGroup,
+					Version: internal.V1Version,
+					Kind:    internal.VolumeSnapshotKind,
+				})
+			})
+
+			AfterEach(func() {
+				deleteVolumeSnapshot(volSnapKey, volSnap.GroupVersionKind())
+			})
+
+			AfterAll(func() {
+				deleteAllVolumeSnapshotCRD()
+			})
+
+			It("Should have correct pvc name as the source in the spec of volume-snapshot", func() {
+				go func() {
+					_, testErr := runOps.createSnapshotFromPVC(ctx, volSnapKey.Name, testSnapshotClass, internal.V1Version,
+						testPVC, testNameSuffix, testClient)
+					resultChan <- testErr
+				}()
+				Eventually(func() error {
+					return testClient.RuntimeClient.Get(ctx, volSnapKey, volSnap)
+				}, timeout, interval).Should(BeNil())
+
+				pvcMap, found, err := unstructured.NestedMap(volSnap.Object, "spec", "source")
+				Expect(found).To(BeTrue())
+				Expect(err).To(BeNil())
+				val, ok := pvcMap["persistentVolumeClaimName"]
+				Expect(ok).To(BeTrue())
+				Expect(val).To(Equal(testPVC))
+			})
+
+			It("Should have correct snapshot-class name in spec field of volume-snapshot", func() {
+				go func() {
+					_, testErr := runOps.createSnapshotFromPVC(ctx, volSnapKey.Name, testSnapshotClass, internal.V1Version,
+						testPVC, testNameSuffix, testClient)
+					resultChan <- testErr
+				}()
+				Eventually(func() error {
+					return testClient.RuntimeClient.Get(ctx, volSnapKey, volSnap)
+				}, timeout, interval).Should(BeNil())
+
+				vscName, found, err := unstructured.NestedFieldNoCopy(volSnap.Object, "spec", "volumeSnapshotClassName")
+				Expect(found).Should(BeTrue())
+				Expect(err).To(BeNil())
+				Expect(vscName).To(Equal(testSnapshotClass))
+			})
+
+			It("Should have correct labels set on volume-snapshot", func() {
+				go func() {
+					_, testErr := runOps.createSnapshotFromPVC(ctx, volSnapKey.Name, testSnapshotClass, internal.V1Version,
+						testPVC, testNameSuffix, testClient)
+					resultChan <- testErr
+				}()
+				Eventually(func() error {
+					return testClient.RuntimeClient.Get(ctx, volSnapKey, volSnap)
+				}, timeout, interval).Should(BeNil())
+
+				verifyTVKResourceLabels(volSnap, testNameSuffix)
+			})
+
+			It("Should not return error when volume-snapshot becomes readyToUse", func() {
+				go func() {
+					_, testErr := runOps.createSnapshotFromPVC(ctx, volSnapKey.Name, testSnapshotClass, internal.V1Version,
+						testPVC, testNameSuffix, testClient)
+					resultChan <- testErr
+				}()
+				Eventually(func() error {
+					return testClient.RuntimeClient.Get(ctx, volSnapKey, volSnap)
+				}, timeout, interval).Should(BeNil())
+
+				// update the readyToUse field
+				Eventually(func() error {
+					return testClient.RuntimeClient.Get(ctx, volSnapKey, volSnap)
+				}, timeout, interval).ShouldNot(HaveOccurred())
+				Expect(unstructured.SetNestedField(volSnap.Object, true, "status", "readyToUse")).To(BeNil())
+				Expect(testClient.RuntimeClient.Status().Update(ctx, volSnap)).To(BeNil())
+
+				// volume-snapshot should be ready-to-use
+				Eventually(func() bool {
+					Expect(testClient.RuntimeClient.Get(ctx, volSnapKey, volSnap)).To(BeNil())
+					ready, found, err := unstructured.NestedBool(volSnap.Object, "status", "readyToUse")
+					Expect(found).To(BeTrue())
+					Expect(err).To(BeNil())
+					return ready
+				}, timeout, interval).Should(BeTrue())
+
+				// successfully complete execution of func
+				Expect(<-resultChan).To(BeNil())
+			})
+		})
+
+		Context("When creating restore pod from volume snapshot", Ordered, func() {
+			var (
+				volSnapKey types.NamespacedName
+				pvcKey     types.NamespacedName
+				podKey     types.NamespacedName
+				volSnap    = &unstructured.Unstructured{}
+				pvc        = &unstructured.Unstructured{}
+				vsCRDsMap  = map[string]bool{vsClassCRD: true, vsContentCRD: true, vsCRD: true}
+				resultChan = make(chan error, 1)
+			)
+
+			BeforeAll(func() {
+				installVolumeSnapshotCRD(v1K8sVersion, vsCRDsMap)
+				checkVolumeSnapshotCRDExists()
+
+				pvc.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind(internal.PersistentVolumeClaimKind))
+				pvcKey = types.NamespacedName{
+					Name:      "ut-pvc-" + internal.GenerateRandomString(6, false),
+					Namespace: installNs,
+				}
+				podKey = types.NamespacedName{
+					Name:      testPodName + "-" + internal.GenerateRandomString(6, false),
+					Namespace: installNs,
+				}
+				volSnapKey = types.NamespacedName{
+					Name:      testVolumeSnapshot,
+					Namespace: installNs,
+				}
+				Eventually(func() error {
+					return createTestVolumeSnapsot(volSnapKey, pvcKey.Name, internal.V1Version)
+				}, timeout, interval).ShouldNot(HaveOccurred())
+				Eventually(func() error {
+					return testClient.RuntimeClient.Get(ctx, volSnapKey, volSnap)
+				}, timeout, interval)
+
+				go func() {
+					_, err := runOps.createRestorePodFromSnapshot(ctx, volSnap, testPVC, podKey.Name, testNameSuffix, testClient.ClientSet)
+					resultChan <- err
+				}()
+			})
+
+			AfterAll(func() {
+				deleteAllVolumeSnapshotCRD()
+			})
+
+			It("Should create pvc for restore pod with volume snapshot as its data-source", func() {
+				snapPvcKey := types.NamespacedName{
+					Name:      testPVC,
+					Namespace: installNs,
+				}
+				Eventually(func() error {
+					return testClient.RuntimeClient.Get(ctx, snapPvcKey, pvc)
+				}, timeout, interval).Should(BeNil())
+
+				ds, found, err := unstructured.NestedMap(pvc.Object, "spec")
+				Expect(found).To(BeTrue())
+				Expect(err).To(BeNil())
+
+				val, ok := ds["storageClassName"]
+				Expect(ok).To(BeTrue())
+				Expect(val).To(Equal(runOps.StorageClass))
+
+				verifyTVKResourceLabels(pvc, testNameSuffix)
+			})
+
+			It("Should create pod using restore PVC", func() {
+				restorePod := &unstructured.Unstructured{}
+				restorePod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind(internal.PodKind))
+				Eventually(func() error {
+					return testClient.RuntimeClient.Get(ctx, podKey, restorePod)
+				}, timeout, interval).Should(BeNil())
+
+				specObj, found, err := unstructured.NestedFieldNoCopy(restorePod.Object, "spec", "volumes")
+				Expect(found).To(BeTrue())
+				Expect(err).To(BeNil())
+
+				specObj = specObj.([]interface{})[0]
+				val, ok := specObj.(map[string]interface{})["name"]
+				Expect(ok).To(BeTrue())
+				Expect(val).To(Equal(VolMountName))
+
+				pvcMap, ok := specObj.(map[string]interface{})["persistentVolumeClaim"]
+				Expect(ok).To(BeTrue())
+
+				val, ok = pvcMap.(map[string]interface{})["claimName"]
+				Expect(ok).To(BeTrue())
+				Expect(val).To(Equal(testPVC))
+
+				verifyTVKResourceLabels(restorePod, testNameSuffix)
+			})
+
+			It("Should not return any error when restore pod goes into ready state", func() {
+				restorePod := &corev1.Pod{}
+				Eventually(func() error {
+					return testClient.RuntimeClient.Get(ctx, podKey, restorePod)
+				}, timeout, interval).Should(BeNil())
+
+				// add pod condition as ready
+				Expect(testClient.RuntimeClient.Get(ctx, podKey, restorePod)).To(BeNil())
+				restorePod.Status.Conditions = append(restorePod.Status.Conditions, corev1.PodCondition{
+					Type:               corev1.PodReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: time.Now()},
+				})
+				Expect(testClient.RuntimeClient.Status().Update(ctx, restorePod)).To(BeNil())
+
+				// The creation of restore should be successful
+				Expect(<-resultChan).To(BeNil())
+			})
+		})
+	})
+
+	Describe("Preflight DNS Pod test scenarios", Ordered, func() {
+		var (
+			podKey     types.NamespacedName
+			dnsPod     = &unstructured.Unstructured{}
+			resultChan = make(chan error)
+		)
+
+		BeforeAll(func() {
+			dnsPod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind(internal.PodKind))
+			podKey = types.NamespacedName{
+				Name:      dnsUtils + testNameSuffix,
+				Namespace: installNs,
+			}
+		})
+
+		AfterEach(func() {
+			deletePod(podKey)
+		})
+
+		It("Should create DNS pod with appropriate spec values", func() {
+			go func() {
+				//_, testErr := runOps.createDNSPodOnCluster(ctx, testNameSuffix, testClient.ClientSet)
+				_, testErr := runOps.createDNSPodOnCluster(ctx, testNameSuffix, testClient.ClientSet)
+				resultChan <- testErr
+			}()
+			Eventually(func() error {
+				return testClient.RuntimeClient.Get(ctx, podKey, dnsPod)
+			}, timeout, interval).Should(BeNil())
+
+			container, found, err := unstructured.NestedFieldNoCopy(dnsPod.Object, "spec", "containers")
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+			container = container.([]interface{})[0]
+
+			verifyTVKResourceLabels(dnsPod, testNameSuffix)
+
+			val, ok := container.(map[string]interface{})["image"]
+			Expect(ok).To(BeTrue())
+			Expect(val).To(Equal(strings.Join([]string{GcrRegistryPath, DNSUtilsImage}, "/")))
+
+			val, ok = container.(map[string]interface{})["name"]
+			Expect(ok).To(BeTrue())
+			Expect(val).To(Equal(dnsContainerName))
+
+			val, ok = container.(map[string]interface{})["resources"]
+			Expect(ok).To(BeTrue())
+
+			Expect(func() bool {
+				limits := val.(map[string]interface{})["limits"]
+				requests := val.(map[string]interface{})["requests"]
+				return runOps.Limits.Cpu().String() == limits.(map[string]interface{})["cpu"] &&
+					runOps.Limits.Memory().String() == limits.(map[string]interface{})["memory"] &&
+					runOps.Requests.Cpu().String() == requests.(map[string]interface{})["cpu"] &&
+					runOps.Requests.Memory().String() == requests.(map[string]interface{})["memory"]
+			}()).To(BeTrue())
+		})
+
+		It("DNS pod should be created without any error after reaching into ready state", func() {
+			go func() {
+				_, testErr := runOps.createDNSPodOnCluster(ctx, testNameSuffix, testClient.ClientSet)
+				resultChan <- testErr
+			}()
+			structPod := &corev1.Pod{}
+			Eventually(func() error {
+				return testClient.RuntimeClient.Get(ctx, podKey, structPod)
+			}, timeout, interval).Should(BeNil())
+
+			// udpate pod to ready condition
+			structPod.Status.Conditions = append(structPod.Status.Conditions, corev1.PodCondition{
+				Type:               corev1.PodReady,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.Time{Time: time.Now()},
+			})
+			Expect(testClient.RuntimeClient.Status().Update(ctx, structPod)).To(BeNil())
+
+			Eventually(func() bool {
+				Expect(testClient.RuntimeClient.Get(ctx, podKey, structPod)).To(BeNil())
+				for _, cond := range structPod.Status.Conditions {
+					if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			Expect(<-resultChan).To(BeNil())
+		})
+	})
+
 	Context("Check rbac-API group and version on the cluster", func() {
 
 		It("Should pass RBAC check when correct rbac-API group and version is provided", func() {
@@ -299,7 +711,9 @@ func installVolumeSnapshotClass(version, driver, vscName string) {
 	}
 	vscUnstrObj.SetGroupVersionKind(vscGVK)
 	vscUnstrObj.SetName(vscName)
-	Expect(testClient.RuntimeClient.Create(ctx, vscUnstrObj)).To(BeNil())
+	Eventually(func() error {
+		return testClient.RuntimeClient.Create(ctx, vscUnstrObj)
+	}, timeout, interval).ShouldNot(HaveOccurred())
 	Eventually(func() error {
 		vscObj := &unstructured.Unstructured{}
 		vscObj.SetGroupVersionKind(vscGVK)
@@ -308,7 +722,6 @@ func installVolumeSnapshotClass(version, driver, vscName string) {
 	vscObj := &unstructured.Unstructured{}
 	vscObj.SetGroupVersionKind(vscGVK)
 	Expect(testClient.RuntimeClient.Get(ctx, types.NamespacedName{Name: vscName}, vscObj)).To(BeNil())
-	fmt.Println("after eventually installVolumeSnapshotClass")
 }
 
 func checkVolumeSnapshotCRDExists() {

--- a/tools/preflight/suite_test.go
+++ b/tools/preflight/suite_test.go
@@ -44,11 +44,14 @@ const (
 	invalidGroup             = "invalid.group.k8s.io"
 	invalidNamespace         = "invalid-ns"
 
-	testPodName       = "test-ut-pod"
-	testSnapshotClass = "ut-snapshot-class"
-	testDriver        = "test.snapshot.driver.io"
-	testMinK8sVersion = "1.10.0"
-	testSentence      = "This is a test-sentence with special char $%^&*() which can be inserted anywhere in test data"
+	testPodName        = "test-ut-pod"
+	testSnapshotClass  = "ut-snapshot-class"
+	testVolumeSnapshot = "ut-volume-snapshot"
+	testPVC            = "test-pvc"
+	testDriver         = "test.snapshot.driver.io"
+	testNameSuffix     = "abcdef"
+	testMinK8sVersion  = "1.10.0"
+	testSentence       = "This is a test-sentence with special char $%^&*() which can be inserted anywhere in test data"
 
 	installNs = internal.DefaultNs
 )

--- a/tools/preflight/utils_unit_test.go
+++ b/tools/preflight/utils_unit_test.go
@@ -4,8 +4,12 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/trilioData/tvk-plugins/internal"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -48,4 +52,90 @@ func createTestPod(name string) {
 	pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind(internal.PodKind))
 	err := testClient.RuntimeClient.Create(ctx, pod)
 	Expect(err).To(BeNil())
+}
+
+func createTestPVC(pvcKey types.NamespacedName) error {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcKey.Name,
+			Namespace: pvcKey.Namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: &runOps.StorageClass,
+			Resources: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceStorage: runOps.PVCStorageRequest,
+				},
+			},
+		},
+	}
+
+	return testClient.RuntimeClient.Create(ctx, pvc)
+}
+
+func createTestVolumeSnapsot(volSnapKey types.NamespacedName, pvcName, snapVer string) error {
+	vs := &unstructured.Unstructured{}
+	vs.Object = map[string]interface{}{
+		"spec": map[string]interface{}{
+			"volumeSnapshotClassName": testSnapshotClass,
+			"source": map[string]string{
+				"persistentVolumeClaimName": pvcName,
+			},
+		},
+	}
+
+	vs.SetName(volSnapKey.Name)
+	vs.SetNamespace(volSnapKey.Namespace)
+	vs.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   StorageSnapshotGroup,
+		Version: snapVer,
+		Kind:    internal.VolumeSnapshotKind,
+	})
+
+	return testClient.RuntimeClient.Create(ctx, vs)
+}
+
+func verifyTVKResourceLabels(obj *unstructured.Unstructured, nameSuffix string) {
+	labelsMap, found, err := unstructured.NestedMap(obj.Object, "metadata", "labels")
+	Expect(found).To(BeTrue())
+	Expect(err).To(BeNil())
+
+	val, ok := labelsMap[LabelPreflightRunKey]
+	Expect(ok).To(BeTrue())
+	Expect(val).To(Equal(nameSuffix))
+
+	val, ok = labelsMap[LabelK8sName]
+	Expect(ok).To(BeTrue())
+	Expect(val).To(Equal(LabelK8sNameValue))
+
+	val, ok = labelsMap[LabelTrilioKey]
+	Expect(ok).To(BeTrue())
+	Expect(val).To(Equal(LabelTvkPreflightValue))
+
+	val, ok = labelsMap[LabelK8sPartOf]
+	Expect(ok).To(BeTrue())
+	Expect(val).To(Equal(LabelK8sPartOfValue))
+}
+
+func deletePod(podKey types.NamespacedName) {
+	pod := &unstructured.Unstructured{}
+	pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind(internal.PodKind))
+	Expect(testClient.RuntimeClient.Get(ctx, podKey, pod)).To(BeNil())
+	Expect(testClient.RuntimeClient.Delete(ctx, pod)).To(BeNil())
+	Eventually(func() bool {
+		err := testClient.RuntimeClient.Get(ctx, podKey, pod)
+		return k8serrors.IsNotFound(err)
+	}, timeout, interval).Should(BeTrue())
+}
+
+func deleteVolumeSnapshot(volSnapKey types.NamespacedName, volSnapGVK schema.GroupVersionKind) {
+	volSnap := &unstructured.Unstructured{}
+	volSnap.SetGroupVersionKind(volSnapGVK)
+	Expect(testClient.RuntimeClient.Get(ctx, volSnapKey, volSnap)).To(BeNil())
+	Expect(testClient.RuntimeClient.Delete(ctx, volSnap))
+	Eventually(func() bool {
+		err := testClient.RuntimeClient.Get(ctx, volSnapKey, volSnap)
+		return k8serrors.IsNotFound(err)
+	}, timeout, interval).Should(BeTrue())
 }


### PR DESCRIPTION
Added env tests for DNS and volume snapshot subroutines wherever possible.