### PR TITLE
:bug: TK-8036 Preflight cleanup patches the status subresources during cleanup and throws error

### DIFF
--- a/tools/preflight/helper.go
+++ b/tools/preflight/helper.go
@@ -660,7 +660,7 @@ func removeFinalizer(ctx context.Context, obj client.Object, cl client.Client) e
 		return gErr
 	}
 
-	if pErr := cl.Status().Patch(ctx, updatedRes, client.RawPatch(types.JSONPatchType, payloadBytes)); pErr != nil {
+	if pErr := cl.Patch(ctx, updatedRes, client.RawPatch(types.JSONPatchType, payloadBytes)); pErr != nil {
 		return pErr
 	}
 


### PR DESCRIPTION
We were patching the status subresource of the object. Rather, we have to patch the `metadata/finalizers` path.