### PR TITLE
:bug: TK-8568 Log collector and preflight should respect the value of the KUBECONFIG variable if it's set

### DIFF
--- a/cmd/log-collector/cmd/cmd_test.go
+++ b/cmd/log-collector/cmd/cmd_test.go
@@ -28,6 +28,7 @@ var _ = Describe("log collector cmd helper unit tests", func() {
 			err := command.PersistentPreRunE(command, []string{})
 			Expect(err).Should(BeNil())
 			Expect(logCollector.KubeConfig).ShouldNot(BeEmpty())
+			Expect(logCollector.KubeConfig).Should(Equal(os.Getenv(internal.KubeconfigEnv)))
 			Expect(logCollector.Clustered).Should(BeFalse())
 			Expect(logCollector.Namespaces).ShouldNot(BeEmpty())
 			Expect(inputFileName).Should(BeEmpty())

--- a/cmd/log-collector/cmd/cmd_test.go
+++ b/cmd/log-collector/cmd/cmd_test.go
@@ -117,11 +117,14 @@ var _ = Describe("log collector cmd helper unit tests", func() {
 			Expect(err).ShouldNot(BeNil())
 		})
 
-		It("Should run using kubeconfig file mentioned in KUBECONFIG env", func() {
+		It("Should run using kubeconfig file mentioned in KUBECONFIG env when no "+
+			"explicit kubeconfig file is provided", func() {
 			testConfigPath := filepath.Join(projectRoot, "manual", "path", "to", "kubeconfig")
-			Expect(internal.CopyFile(internal.KubeConfigDefault, testConfigPath))
-			logCollector.KubeConfig = testConfigPath
-			Expect(logCollector.InitializeKubeClients()).Should(Succeed())
+			Expect(internal.CopyFile(internal.KubeConfigDefault, testConfigPath)).Should(Succeed())
+			Expect(os.Setenv(internal.KubeconfigEnv, testConfigPath)).Should(Succeed())
+			logCollector.KubeConfig = ""
+			command := logCollectorCommand()
+			Expect(command.PersistentPreRunE(command, []string{})).Should(Succeed())
 			Expect(logCollector.KubeConfig).Should(Equal(testConfigPath))
 		})
 

--- a/cmd/log-collector/cmd/cmd_test.go
+++ b/cmd/log-collector/cmd/cmd_test.go
@@ -23,13 +23,11 @@ var _ = Describe("log collector cmd helper unit tests", func() {
 		})
 
 		It("Should initialize log collector objects when valid kubeconfig file path is provided", func() {
-			err := os.Setenv(internal.KubeconfigEnv, internal.KubeConfigDefault)
-			Expect(err).Should(BeNil())
+
 			command := logCollectorCommand()
-			err = command.PersistentPreRunE(command, []string{})
+			err := command.PersistentPreRunE(command, []string{})
 			Expect(err).Should(BeNil())
 			Expect(logCollector.KubeConfig).ShouldNot(BeEmpty())
-			Expect(logCollector.KubeConfig).Should(Equal(internal.KubeConfigDefault))
 			Expect(logCollector.Clustered).Should(BeFalse())
 			Expect(logCollector.Namespaces).ShouldNot(BeEmpty())
 			Expect(inputFileName).Should(BeEmpty())
@@ -119,13 +117,12 @@ var _ = Describe("log collector cmd helper unit tests", func() {
 			Expect(err).ShouldNot(BeNil())
 		})
 
-		It("Should prioritize log collector KUBECONFIG flag value", func() {
-			logCollector.KubeConfig = internal.KubeConfigDefault
-			err := os.Setenv(internal.KubeconfigEnv, "")
-			Expect(err).Should(BeNil())
-			err = logCollector.InitializeKubeClients()
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(logCollector.KubeConfig).Should(Equal(internal.KubeConfigDefault))
+		It("Should run using kubeconfig file mentioned in KUBECONFIG env", func() {
+			testConfigPath := filepath.Join(projectRoot, "manual", "path", "to", "kubeconfig")
+			Expect(internal.CopyFile(internal.KubeConfigDefault, testConfigPath))
+			logCollector.KubeConfig = testConfigPath
+			Expect(logCollector.InitializeKubeClients()).Should(Succeed())
+			Expect(logCollector.KubeConfig).Should(Equal(testConfigPath))
 		})
 
 	})

--- a/cmd/log-collector/cmd/cmd_test.go
+++ b/cmd/log-collector/cmd/cmd_test.go
@@ -23,12 +23,13 @@ var _ = Describe("log collector cmd helper unit tests", func() {
 		})
 
 		It("Should initialize log collector objects when valid kubeconfig file path is provided", func() {
-
+			err := os.Setenv(internal.KubeconfigEnv, internal.KubeConfigDefault)
+			Expect(err).Should(BeNil())
 			command := logCollectorCommand()
-			err := command.PersistentPreRunE(command, []string{})
+			err = command.PersistentPreRunE(command, []string{})
 			Expect(err).Should(BeNil())
 			Expect(logCollector.KubeConfig).ShouldNot(BeEmpty())
-			Expect(logCollector.KubeConfig).Should(Equal(os.Getenv(internal.KubeconfigEnv)))
+			Expect(logCollector.KubeConfig).Should(Equal(internal.KubeConfigDefault))
 			Expect(logCollector.Clustered).Should(BeFalse())
 			Expect(logCollector.Namespaces).ShouldNot(BeEmpty())
 			Expect(inputFileName).Should(BeEmpty())
@@ -117,5 +118,15 @@ var _ = Describe("log collector cmd helper unit tests", func() {
 			err := logCollector.InitializeKubeClients()
 			Expect(err).ShouldNot(BeNil())
 		})
+
+		It("Should prioritize log collector KUBECONFIG flag value", func() {
+			logCollector.KubeConfig = internal.KubeConfigDefault
+			err := os.Setenv(internal.KubeconfigEnv, "")
+			Expect(err).Should(BeNil())
+			err = logCollector.InitializeKubeClients()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(logCollector.KubeConfig).Should(Equal(internal.KubeConfigDefault))
+		})
+
 	})
 })

--- a/cmd/log-collector/cmd/root.go
+++ b/cmd/log-collector/cmd/root.go
@@ -24,7 +24,7 @@ func logCollectorCommand() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&namespaces, namespacesFlag, namespacesShort, namespacesDefault, namespacesUsage)
 	cmd.Flags().BoolVarP(&clustered, clusteredFlag, clusteredShort, clusteredDefault, clusteredUsage)
 	cmd.Flags().StringVarP(&kubeConfig, internal.KubeconfigFlag,
-		internal.KubeconfigShorthandFlag, internal.KubeConfigDefault, internal.KubeconfigUsage)
+		internal.KubeconfigShorthandFlag, internal.GetKubeconfigPath(), internal.KubeconfigUsage)
 	cmd.Flags().BoolVarP(&keepSource, keepSourceFlag, keepSourceShort, keepSourceDefault, keepSourceUsage)
 	cmd.Flags().StringVarP(&logLevel, internal.LogLevelFlag, internal.LogLevelFlagShorthand, internal.DefaultLogLevel, internal.LogLevelUsage)
 	cmd.Flags().StringVarP(&inputFileName, configFileFlag, configFlagShorthand, "", configFileUsage)

--- a/cmd/preflight/cmd/helper_test.go
+++ b/cmd/preflight/cmd/helper_test.go
@@ -326,6 +326,13 @@ var _ = Describe("Preflight cmd helper unit tests", func() {
 		})
 	})
 
+	Context("validateInitKubeEnv func test-case", func() {
+		It("Should perform preflight check using kubeconfig file mentioned in KUBECONFIG env", func() {
+			preflight.InitKubeEnv("")
+			Expect(kubeconfig).Should(Equal(os.Getenv(internal.KubeconfigEnv)))
+		})
+	})
+
 	Context("validateCleanupFields func test-cases", func() {
 		BeforeEach(func() {
 			cmdOps.Cleanup = preflight.Cleanup{

--- a/cmd/preflight/cmd/helper_test.go
+++ b/cmd/preflight/cmd/helper_test.go
@@ -237,6 +237,10 @@ var _ = Describe("Preflight cmd helper unit tests", func() {
 
 	Context("managePreflightInputs func test-cases", func() {
 
+		BeforeEach(func() {
+			internal.KubeConfigDefault = os.Getenv(internal.KubeconfigEnv)
+		})
+
 		It("Should set namespace as default when namespace is not explicitly provided", func() {
 			inputFileName = ""
 			cmdOps.Run.Namespace = ""
@@ -265,6 +269,19 @@ var _ = Describe("Preflight cmd helper unit tests", func() {
 			cmdOps.Run.LogLevel = ""
 			Expect(managePreflightInputs(&cobra.Command{})).Should(BeNil())
 			Expect(cmdOps.Run.LogLevel).Should(Equal(internal.DefaultLogLevel))
+		})
+
+		It("Should perform preflight check using kubeconfig file mentioned in KUBECONFIG env", func() {
+			err = os.Setenv(internal.KubeconfigEnv, internal.KubeConfigDefault)
+			Expect(err).Should(BeNil())
+			Expect(cmdOps.Run.Kubeconfig).Should(Equal(internal.KubeConfigDefault))
+		})
+
+		It("Should perform preflight check by prioritize the flag value of KUBECONFIG", func() {
+			cmdOps.Run.Kubeconfig = internal.KubeConfigDefault
+			err = os.Setenv(internal.KubeconfigEnv, "")
+			Expect(err).Should(BeNil())
+			Expect(cmdOps.Run.Kubeconfig).Should(Equal(internal.KubeConfigDefault))
 		})
 
 	})
@@ -323,13 +340,6 @@ var _ = Describe("Preflight cmd helper unit tests", func() {
 			terr := validateRunOptions()
 			Expect(terr).ToNot(BeNil())
 			Expect(terr.Error()).To(ContainSubstring("request CPU cannot be greater than limit CPU"))
-		})
-	})
-
-	Context("validateInitKubeEnv func test-case", func() {
-		It("Should perform preflight check using kubeconfig file mentioned in KUBECONFIG env", func() {
-			preflight.InitKubeEnv("")
-			Expect(kubeconfig).Should(Equal(os.Getenv(internal.KubeconfigEnv)))
 		})
 	})
 

--- a/cmd/preflight/cmd/helper_test.go
+++ b/cmd/preflight/cmd/helper_test.go
@@ -267,7 +267,8 @@ var _ = Describe("Preflight cmd helper unit tests", func() {
 			Expect(cmdOps.Run.LogLevel).Should(Equal(internal.DefaultLogLevel))
 		})
 
-		It("Should perform preflight check using kubeconfig file mentioned in KUBECONFIG env", func() {
+		It("Should perform preflight check using kubeconfig file mentioned in KUBECONFIG env when no explicit"+
+			" kubeconfig file is provided", func() {
 			testConfigPath := filepath.Join(projectRoot, "manual", "path", "to", "kubeconfig")
 			cmdOps.Run.Kubeconfig = ""
 			kubeconfig = testConfigPath

--- a/cmd/preflight/cmd/helper_test.go
+++ b/cmd/preflight/cmd/helper_test.go
@@ -237,10 +237,6 @@ var _ = Describe("Preflight cmd helper unit tests", func() {
 
 	Context("managePreflightInputs func test-cases", func() {
 
-		BeforeEach(func() {
-			internal.KubeConfigDefault = os.Getenv(internal.KubeconfigEnv)
-		})
-
 		It("Should set namespace as default when namespace is not explicitly provided", func() {
 			inputFileName = ""
 			cmdOps.Run.Namespace = ""
@@ -272,16 +268,11 @@ var _ = Describe("Preflight cmd helper unit tests", func() {
 		})
 
 		It("Should perform preflight check using kubeconfig file mentioned in KUBECONFIG env", func() {
-			err = os.Setenv(internal.KubeconfigEnv, internal.KubeConfigDefault)
-			Expect(err).Should(BeNil())
-			Expect(cmdOps.Run.Kubeconfig).Should(Equal(internal.KubeConfigDefault))
-		})
-
-		It("Should perform preflight check by prioritize the flag value of KUBECONFIG", func() {
-			cmdOps.Run.Kubeconfig = internal.KubeConfigDefault
-			err = os.Setenv(internal.KubeconfigEnv, "")
-			Expect(err).Should(BeNil())
-			Expect(cmdOps.Run.Kubeconfig).Should(Equal(internal.KubeConfigDefault))
+			testConfigPath := filepath.Join(projectRoot, "manual", "path", "to", "kubeconfig")
+			cmdOps.Run.Kubeconfig = ""
+			kubeconfig = testConfigPath
+			Expect(managePreflightInputs(&cobra.Command{})).Should(BeNil())
+			Expect(cmdOps.Run.Kubeconfig).Should(Equal(testConfigPath))
 		})
 
 	})

--- a/cmd/preflight/cmd/root.go
+++ b/cmd/preflight/cmd/root.go
@@ -36,7 +36,7 @@ func Execute() {
 // initializes flags and logger for the application
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&kubeconfig, internal.KubeconfigFlag,
-		internal.KubeconfigShorthandFlag, "", internal.KubeconfigUsage)
+		internal.KubeconfigShorthandFlag, internal.GetKubeconfigPath(), internal.KubeconfigUsage)
 	rootCmd.PersistentFlags().StringVarP(&namespace, NamespaceFlag, namespaceFlagShorthand, internal.DefaultNs, namespaceUsage)
 	rootCmd.PersistentFlags().StringVarP(&logLevel, internal.LogLevelFlag,
 		internal.LogLevelFlagShorthand, internal.DefaultLogLevel, internal.LogLevelUsage)

--- a/internal/kube_helper.go
+++ b/internal/kube_helper.go
@@ -7,13 +7,14 @@ import (
 	"os"
 	"path/filepath"
 
+	ctrlRuntime "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	client "k8s.io/client-go/kubernetes"
-	ctrlRuntime "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	// To authenticate kubeEnv for fcp, azure, etc. cluster
 	_ "k8s.io/client-go/plugin/pkg/client/auth"

--- a/internal/kube_helper.go
+++ b/internal/kube_helper.go
@@ -127,6 +127,14 @@ func NewConfigFromCommandline(kubeConfig string) (string, error) {
 	return "", nil
 }
 
+func GetKubeconfigPath() string {
+	kubeConf, exist := os.LookupEnv(KubeconfigEnv)
+	if !exist {
+		kubeConf = KubeConfigDefault
+	}
+	return kubeConf
+}
+
 func normalizeFile(path *string) error {
 	// If the path uses the homedir ~, expand the path.
 	var err error


### PR DESCRIPTION
<!-- please add an icon to the title of this PR, and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
