### PR TITLE
:bug: TK-9140 Remove Helm warnings if the clusters being tested is OCP in the Trilio Preflight check

### DIFF
--- a/tools/preflight/preflight_test.go
+++ b/tools/preflight/preflight_test.go
@@ -179,7 +179,7 @@ func preflightFuncsTestcases() {
 
 			Context("When helm binary does not satisfy minimum version requirement", func() {
 
-				It("Should return error when helm version does not satisfy the minimum required helm version", func() {
+				It("Should return error when the current helm version does not satisfy the minimum required helm version", func() {
 					err := runOps.validateHelmVersion(invalidHelmVersion)
 					Expect(err).ToNot(BeNil())
 					Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(


### PR DESCRIPTION

<!-- please add an icon to the title of this PR, and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Related ticket:- [TK-9140](https://triliodata.atlassian.net/browse/TK-9140)


[TK-9140]: https://triliodata.atlassian.net/browse/TK-9140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ