### PR TITLE
🐛 Updated github action workflow file to fix incorrect binary path

### DIFF
--- a/.github/workflows/plugin-packages.yml
+++ b/.github/workflows/plugin-packages.yml
@@ -3,7 +3,7 @@ name: Plugin Packages CI
 on:
   push:
     branches:
-      - 'main'
+      - '*'
     tags:
       - 'v*.*.*'
   pull_request:
@@ -405,8 +405,8 @@ jobs:
           export_default_credentials: true
 
       - name: Upload Log-Collector binary to GCS artifact
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: gsutil cp dist/log-collector_linux_amd64/log-collector gs://trilio-artifacts/tvk-plugins/log-collector/main/log-collector
+        if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
+        run: gsutil cp dist/log-collector_linux_amd64_v1/log-collector gs://trilio-artifacts/tvk-plugins/log-collector/${{ startsWith(github.ref, 'refs/heads/') && github.ref_name || github.head_ref }}/log-collector
 
   # pre-release job determines whether to create release or not and sets job variables which will be used to decide
   # what packages(preflight, cleanup, log-collector) should be included in release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 # goreleaser build and release config
+version: 2
 builds:
 - id: log-collector
   main: ./cmd/log-collector/
@@ -34,21 +35,21 @@ archives:
 - id: log-collector-archive
   name_template: |-
     log-collector_{{ .Tag }}_{{ .Os }}_{{ .Arch -}}
-  builds:
+  ids:
     - log-collector
   format_overrides:
     - goos: windows
-      format: zip
+      formats: zip
   files: ["LICENSE.md"]
 
 - id: preflight-archive
   name_template: |-
     preflight_{{ .Tag }}_{{ .Os }}_{{ .Arch -}}
-  builds:
+  ids:
     - preflight
   format_overrides:
     - goos: windows
-      format: zip
+      formats: zip
   files: ["LICENSE.md"]
 
 checksum:


### PR DESCRIPTION


<!-- please add an icon to the title of this PR, and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Updated `github action workflow file` to fix incorrect binary path, `.goreleaser.yml` to fix deprecated fields. Github action workflow was failing to push log collector binary created to GCS bucket.